### PR TITLE
4-level nav; 2-column /themes/

### DIFF
--- a/source/includes/_themes_style_editor.md
+++ b/source/includes/_themes_style_editor.md
@@ -33,9 +33,9 @@ There are some syntax patterns involved that Style Editor will understand to hel
 
 e.g.
 
-```
+`
 @color-header-background: #FFFFFF;
-```
+`
 
 This will generate a color picker with the label “Header Background”, set to #FFFFFF (white) by default.
 
@@ -79,11 +79,9 @@ This will add a shade of orange and a shade of purple to the end of the list of 
 
 e.g.
 
-```
-//! @section: Header
-@color-header-background: #FFF;
-//! @endsection
-```
+`//! @section: Header`  
+`@color-header-background: #FFF;`  
+`//! @endsection`  of
 
 This will create a section in the left navigation with the title “Header”, which will house the “Header Background” variable.
 

--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -11,7 +11,7 @@
 
   var makeToc = function() {
     global.toc = $("#toc").tocify({
-      selectors: 'h1, h2',
+      selectors: 'h1, h2, h3, h4',
       extendPage: false,
       theme: 'none',
       smoothScroll: false,

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -188,6 +188,22 @@ html, body {
     .tocify-item>a {
       padding-left: $nav-padding + $nav-indent;
       font-size: 12px;
+      // Nested for nested 3rd level, from: https://github.com/tripit/slate/wiki/Deeper-Nesting:
+        .tocify-subheader {
+          .tocify-item>a {
+            // Styling here for a level 2 nesting. For example -> 
+            padding-left: $nav-padding + calc($nav-indent * 2);
+            font-size: 12px;
+          }
+        }
+          // Nested for nested 4th level, from: https://github.com/tripit/slate/wiki/Deeper-Nesting:
+            .tocify-subheader {
+              .tocify-item>a {
+                // Styling here for a level 3 nesting. For example -> 
+                padding-left: $nav-padding + calc($nav-indent * 3);
+                font-size: 12px;
+              }
+            }
     }
 
     // for embossed look:
@@ -621,4 +637,6 @@ html, body {
 
 .themes .dark-box { display:none }
 
-.themes .content > h1,.themes .content > h2,.themes .content > h3,.themes .content > h4,.themes .content > h5, .themes .content > h6, .themes .content > p, .themes .content > table, .themes .content > ul, .themes .content > ol, .themes .content > aside, .themes .content > dl { margin-right: 0; }
+.themes .content > h1,.themes .content > h2,.themes .content > h3,.themes .content > h4,.themes .content > h5, .themes .content > h6, .themes .content > p, .themes .content > table, .themes .content > ul, .themes .content > ol, .themes .content > aside, .themes .content > dl, .themes .content > code, .themes .content > pre, .themes .content pre > code, .themes .content > blockquote { margin-right: 0; }
+
+/* .themes .content > pre, .themes .content > code, .themes .content pre > code, .themes .content > blockquote { width: 0%; padding: 0; float: none; clear: both; } */


### PR DESCRIPTION
Edited screen.css.scss & _toc.js to enable 4-level nav pane (indents
don’t yet work).

Edited screen.css.scss to partly suppress dark 2rd column within
…/themes/ (needs further work).