### PR TITLE
Nav subhead fixes + "Send Feedback/Edits" link

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -55,6 +55,7 @@ under the License.
 		<a href="#">Themes</a>
 		<a href="#">Changelog</a>
 		<a href="#">Support</a>
+		<a href="#">Send Feedback/Edits</a>
 	</div>
 	<div class="actions">
 		<a href="#">Log in</a>

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -69,7 +69,7 @@ $phone-width: $tablet-width - $nav-width; // min width before reverting to mobil
 // FONTS
 ////////////////////
 %default-font {
-  font-family: "Myriad Pro", "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei","微软雅黑", STXihei, "华文细黑", sans-serif;
+  font-family: "Myriad Pro", "PT Sans", "Droid Sans", "Noto Sans", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei","微软雅黑", STXihei, "华文细黑", sans-serif;
   font-size: 13px;
 }
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -184,7 +184,8 @@ html, body {
   .tocify-subheader {
     display: none; // tocify will override this when needed
     background-color: $nav-subitem-bg;
-    font-weight: 500;
+    font-weight: bold;
+    /* font-weight: 500; */
     .tocify-item>a {
       padding-left: $nav-padding + $nav-indent;
       font-size: 12px;


### PR DESCRIPTION
(1) Nav subheads consistently set to “font-weight: bold;” in
screen.css.scss. (2) “Send Feedback/Edits" link added in layout.erb.