### PR TITLE
Top nav fixed; /themes/ layout trimmed

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -59,7 +59,7 @@ under the License.
 	</div>
 	<div class="actions">
 		<a href="#">Log in</a>
-		<a href="#">Register</a>
+		<a href="#" class="register">Register</a>
 	</div>
     </div>
     <div class="tocify-wrapper">

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -294,11 +294,11 @@ html, body {
     background-color: $examples-bg;
     position: absolute;
     right: 0;
-    top: 0;
+    top: 78px;
     bottom: 0;
   }
 
-  .lang-selector {
+.lang-selector {
     position: fixed;
     z-index: 50;
     border-bottom: 5px solid $lang-select-active-bg;
@@ -345,6 +345,7 @@ html, body {
   // to place content above the dark box
   position: relative;
   z-index: 30;
+  top: 78px;
 
   &:after {
     content: '';
@@ -652,6 +653,10 @@ iframe {padding-left: 2.5em; }
 /* Added 3/4/16, to force themes subdirectory to 2-column layout: */
 .themes .dark-box { display:none }
 
+.themes .content {
+     max-width: 80%;
+}
+
 .themes .content > h1,.themes .content > h2,.themes .content > h3,.themes .content > h4,.themes .content > h5, .themes .content > h6, .themes .content > p, .themes .content > table, .themes .content > ul, .themes .content > ol, .themes .content > aside, .themes .content > dl, .themes .content > code, .themes .content > pre, .themes .content pre > code, .themes .content > blockquote { margin-right: 0; }
 
 /* .themes .content > pre, .themes .content > code, .themes .content pre > code, .themes .content > blockquote { width: 0%; padding: 0; float: none; clear: both; } */
@@ -662,6 +667,7 @@ iframe {padding-left: 2.5em; }
     margin-left: 28px !important;
     padding-right: 0 !important;
     float: none;
+    max-width: 90%;
     width: 100%; }
 
 
@@ -669,9 +675,9 @@ iframe {padding-left: 2.5em; }
 
 .page-header {
     height: 58px;
-    /* z-index: 999; */
-    /* position:fixed;
-    top:0; */
+    z-index: 999;
+    position: fixed /* !important */;
+    top:0;
     width: 100%;
     background-color: #5754ff;
     padding: 10px;


### PR DESCRIPTION
Top nav bar is now sticky. “Register” button’s outline is restored.
/themes/ layout now trims max-width (by %) for body text and code
blocks.