### PR TITLE
Top-nav splitter moved right

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -735,7 +735,7 @@ img {
     top: 6px;
     position: relative;
     /* margin-left: 40px; */
-    margin-left: 66px;
+    margin-left: 110px;
     margin-right: 40px;
 }
 


### PR DESCRIPTION
Top-nav splitter moved right to line up with left-nav’s right border.