### PR TITLE
Font tweaks

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -76,7 +76,8 @@ $phone-width: $tablet-width - $nav-width; // min width before reverting to mobil
 
 %default-font {
   font-family: "Source Sans Pro", Roboto, Lato, "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei","微软雅黑", STXihei, "华文细黑", sans-serif;
-  font-size: 13px;
+  /* font-size: 13px; */
+  font-size: 14px;
 }
 
 %header-font {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -704,11 +704,12 @@ iframe {padding-left: 2.5em; }
     height: 40px;
     /* line-height: 60px; */
     line-height: 30px;
-    font-size: 18px;
+    /* font-size: 18px; */
+    font-size: 16px;
 }
 
 page-header a {
-    font-variant: all-small-caps;
+    /* font-variant: all-small-caps; */
     text-decoration: none;
     font-weight: bold;  /* Should probably change to SemiBold = 600 */
     color: white;
@@ -745,7 +746,7 @@ img {
     text-decoration: none;
     /* font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; */
     font-family: default-font;
-    font-variant: small-caps;
+    /* font-variant: small-caps; */
     /* font-weight: bold; */
     font-weight: 600;  /* SemiBold to avoid bloat */
 }
@@ -760,7 +761,7 @@ img {
     text-decoration: none;
     /* font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; */
     font-family: default-font;
-    font-variant: small-caps;
+    /* font-variant: small-caps; */
     /* font-weight: bold; */
     font-weight: 600;  /* SemiBold to avoid bloat */
 }


### PR DESCRIPTION
Enlarged body text from 13 > 14 px, for readability. Shrank top-nav
text from 18 > 16 px, & removed small-caps attribute, to scream less.
15 px or even 14 px (matching left-nav H1’s) might be a better
final choice.