### PR TITLE
API content + CSS sync

### DIFF
--- a/source/includes/_api_approval-requirements.md
+++ b/source/includes/_api_approval-requirements.md
@@ -1,0 +1,66 @@
+## Introduction
+
+Our submission guidelines aim to protect the merchant experience, and to provide enough structure for you to develop apps efficiently and effectively.
+
+## App Requirements
+
+*   Apps must perform as described.
+
+*   All information supplied as part of the app submission process must be genuine and accurate.
+
+*   Apps must provide pricing information – including pricing for starting a new service, and the cost of services after the free trial.
+
+*   All API requests must be made using OAuth authentication.
+
+*   Apps must be production-ready and free of defects.
+
+<div class="bui-message bui-message-info"><span class="bui-message-text">PRO TIP: Install and test your app thoroughly prior to submission. Be sure to install and run your app inside of your sandbox store as a draft area to conduct your tests.</span></div>
+
+*   Apps must function properly on all [supported browsers](/api/browsers), and must conform to the [user interface constraints](/api/ui-constraints) – including P3P policies as necessary, and no mixed content.
+
+*   The entire app should operate within the iframe that opens when the user clicks on your app icon in the launch bar of the Control Panel. Exceptions may be made for apps that need to authenticate to other services using OAuth – as long as they open a new tab to do so.
+
+*   Apps must be easy to use.
+
+*   Whenever possible, apps must use the API resources to auto-fill and obtain information rather than prompting the user. Apps requesting information that can be auto-filled will be rejected.
+
+<div class="bui-message bui-message-info"><span class="bui-message-text">PRO TIP: The store name, phone number, and other information can be obtained from the [Store&#160;Information](/api/store) resource.</span></div>
+
+*   The user ID and email address from the [OAuth flow](/api/load#process) should allow you to automatically log the merchant into any additional systems. Apps that provide the merchant with a single-sign-on experience are preferred.
+
+*   Apps must return some HTML in response to GET requests to the [Auth Callback URI](/api/load#process).
+
+*   Must use a TLS/SSL certificate signed by a valid certificate authority. Self-signed certificates will generate browser warnings and are not acceptable.
+
+*   No competitor integrations or references should appear in the app or in marketing materials.
+
+*   Any instances of the BigCommerce brand name must match current branding, i.e., one word with an uppercase "C".
+
+*   Apps must have all required information and files discussed in [App Submission](/api/completing-reg).
+
+## Types of apps we're accepting
+
+| Accepting | Not accepting |
+| --- | --- |
+| Accounting | Real-Time Tax |
+| Advertising | Customized Checkout |
+| Analytics | Real-time Shipping Rate updates |
+| Cloud integration | Payment Methods |
+| Customer feedback |
+| Drop shipping |
+| Email marketing |
+| Live chat |
+| Marketing |
+| Merchandising |
+| Mobile |
+| Multichannel listing |
+| Order fulfillment |
+| Order management |
+| Point of sale |
+| Product review |
+| Shipping |
+| Shopping comparison |
+| Social media |
+| Split testing |
+
+Questions? Please contact [appstore@bigcommerce.com](mailto:appstore@bigcommerce.com)

--- a/source/includes/_api_ui-constraints.md
+++ b/source/includes/_api_ui-constraints.md
@@ -1,0 +1,26 @@
+## Introduction
+
+OAuth apps benefit from a high level of integration with the BigCommerce platform. Users interacting with your app will enjoy a seamless experience. BigCommerce achieves this by rendering your app's user interface inside of an iframe within the control panel. To ensure acceptance into the App Store, your app should be able to perform all of its functions inside of the iframe.
+
+While very usable and friendly, the iframe approach does require special attention from app developers. The remainder of this page discusses several functional areas to consider when designing and developing your app.
+
+*   [Mixed content](#mixed)
+*   [Same-origin policies](#xss)
+*   [P3P and cookies](#p3p)
+
+## About mixed content
+
+The BigCommerce control panel is served over TLS/SSL. Your app must be hosted on a web server that accepts and sends TLS/SSL requests. In addition, all of the resources referenced in the HTML that you present to the end users must be served over TLS/SSL. You may find protocol-agnostic addressing helpful.
+
+If the user interface retrieves images, scripts, or other assets over a connection not encrypted with TLS/SSL, the user will experience errors and possibly an inability to interact with your app. Before submitting your app, use an [online crawler](https://www.jitbit.com/sslcheck/) to check for insecure content.
+
+## About same-origin policies
+
+[Same-origin policies](http://en.wikipedia.org/wiki/Same-origin_policy) restrict apps running within iframes from performing certain activities, such as interacting with other services and making OAuth connections. While apps that operate within the BigCommerce iframe get strong preference during App Store considerations, we sometimes make exceptions for apps that need to interact and authenticate to other services. If your app requires this, we advise you to open a new tab for actions that cannot occur within the iframe.
+
+## About P3P and cookies
+
+Internet Explorer is one of the browsers that BigCommerce [supports](/api/browsers) and our merchants do use it to access the control panel. If your app needs to set a cookie, you will need to craft a [P3P policy](http://en.wikipedia.org/wiki/P3P). Otherwise, your app will experience issues on Internet Explorer. Please review the following pages for more information.
+
+*   [Craft a P3P policy to make IE behave](http://www.techrepublic.com/blog/software-engineer/craft-a-p3p-policy-to-make-ie-behave/)
+*   [MSDN Intro to P3P Cookie Blocking](http://blogs.msdn.com/b/ieinternals/archive/2013/09/17/simple-introduction-to-p3p-cookie-blocking-frame.aspx)

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -830,7 +830,6 @@ table td:nth-child(3) {
   word-break: break-word;
 }
 
-<<<<<<< HEAD
 .vtwo-links {
   padding: 0 15px 0 15px;
 
@@ -839,11 +838,9 @@ table td:nth-child(3) {
     color: #595864;
   }
 }
-=======
+
 /* Added 4/27/16 to constrain body text's width: */
 .themes .content {
     width: 80%;
     min-width: 850px;
 }
-
->>>>>>> master


### PR DESCRIPTION
Added "App Req's" + "UI Constraints" pages. (Not yet linked to index page or left nav.)
In screen.css.scss, resolved faux conflict between .themes .content vs. .vtwo-links selectors.