### PR TITLE
Category object – spelling fixes

### DIFF
--- a/source/includes/_api_CRUD_store_information.md
+++ b/source/includes/_api_CRUD_store_information.md
@@ -48,6 +48,9 @@ Gets metadata about a store.
   "is_price_entered_with_tax": false,
   "active_comparison_modules": [
 
-  ]
+  ],
+  "features": {
+    "stencil_enabled": false
+  }
 }
 ```

--- a/source/includes/_api_objects_category.md
+++ b/source/includes/_api_objects_category.md
@@ -8,7 +8,7 @@ Index of hierarchical categories used to organize and group products.
 | **OAuth Scopes** | `store_v2_products`
 ||`store_v2_products_read_only`
 
-## Cateogry Object - Properties
+## Category Object – Properties
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/source/includes/_api_objects_store_information.md
+++ b/source/includes/_api_objects_store_information.md
@@ -33,8 +33,10 @@ Profile of an individual store.
 | plan_name | string | Name of the Bigcommerce plan this store belongs to |
 | plan_level | string | BigCommerce plan level to which this store is subscribed |
 | logo | object |
-| is_price_entered_with_tax | boolean | A BOOLEAN value that indicates whether or not prices are entered with tax |
+| is_price_entered_with_tax | boolean | A Boolean value that indicates whether or not prices are entered with tax |
 | active_comparison_modules | array |
+| features | object | Array of flags for features that affect app compatibility or functionality. Child \"stencil_enabled\" element is a Boolean that indicates whether a store is using a Stencil theme. |
+
 
 ## Webhook Events
 

--- a/source/includes/_changelog_2016.md
+++ b/source/includes/_changelog_2016.md
@@ -1,5 +1,25 @@
 # 2016
 
+## May
+
+### Store Information endpoint adds "features" array
+
+The Store Information endpoint now provides a `features` array, whose elements flag features that affect app compatibility or functionality. This array's initial `stencil_enabled` (Boolean) element indicates whether a store is using a Stencil theme, as in this example:
+
+    "features": {
+        "stencil_enabled": true
+    }
+
+BigCommerce will add other features to this array as warranted. For details, please see our documentation on the Store Information [object](/api/v2/#store-information-object) and [resource](/api/v2/#get-a-store-s-information).
+
+
+### Stencil custom/private theme uploads now available
+
+Developers can now upload custom/private Stencil themes to storefronts, via the BigCommerce control panel. 
+
+For details, please see [this Knowledge Base article](https://support.bigcommerce.com/articles/Public/Custom-Theme-Upload) and [this troubleshooting page](https://stencil.bigcommerce.com/docs/uploading-a-custom-theme).
+
+
 ## April 
 
 ### New API SKU Properties Available

--- a/source/includes/_changelog_2016.md
+++ b/source/includes/_changelog_2016.md
@@ -10,7 +10,7 @@ The Store Information endpoint now provides a `features` array, whose elements f
         "stencil_enabled": true
     }
 
-BigCommerce will add other features to this array as warranted. For details, please see our documentation on the Store Information [object](/api/v2/#store-information-object) and [resource](/api/v2/#get-a-store-s-information).
+BigCommerce will add other features to this array, as warranted. For details, please see our documentation on the Store Information [object](/api/v2/#store-information-object) and [resource](/api/v2/#get-a-store-s-information).
 
 
 ### Stencil custom/private theme uploads now available


### PR DESCRIPTION
Changed “Cateogry” to “Category”.