### PR TITLE
Changelog 2016 sync

### DIFF
--- a/source/includes/_changelog_2016.md
+++ b/source/includes/_changelog_2016.md
@@ -2,6 +2,13 @@
 
 ## June
 
+### API: Order Shipment resource adds "shipping_provider" field
+
+The Order Shipment resource has a new `shipping_provider` field, which contains the enum of the delivery service used to fulfill the shipment.
+
+We have added this field to the [Order Shipment](/api/v2#shipping-methods) documentation, including the sample responses for Order Shipment endpoints that can return this field.
+
+
 ### Store Information endpoint now passes secure store URL
 
 The Store Information endpoint now provides a `secure_url` field, containing the store's secure (HTTPS) URL.


### PR DESCRIPTION
This just updates `_changelog_2016.md` to sync with the `shipping_provider` field’s announcement in the live Dev Portal on 6/16/16.