### PR TITLE
Various CSS fixes to the responsive navbar

### DIFF
--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -140,7 +140,7 @@
     text-transform: uppercase;
     padding-top: 3%;
     padding-bottom: 3%;
-    letter-spacing: 1.8px;  
+    letter-spacing: 1.8px;
   }
 
 table td:nth-child(3) {
@@ -164,8 +164,8 @@ table td:nth-child(3) {
 .jumptarget::before {
   content: "";
   display: block;
-  height: 85px; 
-  margin: -85px 0 0; 
+  height: 85px;
+  margin: -85px 0 0;
 }
 
 #support-h1 {
@@ -175,7 +175,7 @@ table td:nth-child(3) {
   position: relative;
   left: 11%;
   text-transform: uppercase;
-  letter-spacing: 1.8px;  
+  letter-spacing: 1.8px;
 }
 
 .api-nav {
@@ -204,4 +204,48 @@ table td:nth-child(3) {
 
 .btn:focus {
   outline: 0;
+}
+
+/* Custom styles for the top navigation when the menu is expanded by default */
+
+@media only screen and (min-width: 931px) {
+    .top-bar {
+        margin: 0;
+        max-width: none;
+        padding: 0;
+    }
+
+    .top-bar .title-area {
+      min-width: 285px;
+      padding-left: 25px;
+      padding-top: 0;
+      vertical-align: middle;
+      width: 10%;
+    }
+
+    .top-bar-section,
+    [top-bar-section] {
+      width: 48%;
+    }
+
+    .top-bar-section ul,
+    [top-bar-section] ul {
+      background: none;
+    }
+
+    .top-bar-section ul li,
+    [top-bar-section] ul li {
+      display: inline-block;
+      float: none;
+    }
+
+    .top-bar-actions {
+      padding-right: 25px;
+      width: 30%;
+    }
+
+    .top-bar .optional,
+    [top-bar] .optional {
+      display: inline-block;
+    }
 }

--- a/source/stylesheets/_navbar.scss
+++ b/source/stylesheets/_navbar.scss
@@ -770,7 +770,7 @@ header {
 
 @media (max-width: 768px) {
     .top-bar .title-area, [top-bar] .title-area {
-        margin-left: 0;
+        margin: 23px 0;
         padding: 0;
         text-align: center;
     }
@@ -817,6 +817,12 @@ header {
 @media only screen and (max-width:450px) {
     .top-bar .name img, [top-bar] .name img {
         position: relative;
-        width: 30%
+        width: 30%;
+        margin: 0;
+    }
+
+    .top-bar .title-area,
+    [top-bar] .title-area {
+        margin: 12px 10px 0;
     }
 }


### PR DESCRIPTION
Not my proudest work, but hey.

- Assigned new widths for each header section so they never overflow
- Fixed heights of header on mobile
- made header full width
- Logo section is now only as wide as the sidebar nav
- New breakpoint which sets the logo section width to sidebar width when sidebar is open by default. Otherwise reverts to previous styles.

<img width="817" alt="screen shot 2016-07-11 at 3 52 43 pm" src="https://cloud.githubusercontent.com/assets/2830104/16721060/b97d0402-477f-11e6-8aac-f519b45bd8c1.png">

@bc-AlyssNoland 
