### PR TITLE
Callouts – final tweaks

### DIFF
--- a/source/includes/_api_registration.md
+++ b/source/includes/_api_registration.md
@@ -10,10 +10,27 @@ The app registration wizard requests a number of details that you may not know j
 
 ### <span class="jumptarget"> Technical Requirements </span>
 
+<aside class="notice">
+MIGRATION NOTE:<br>
+Stacked heads; insert something here!
+</aside>
+
+<aside class="success">
+MIGRATION NOTE:<br>
+Stacked heads; insert something here!
+</aside>
+
 <aside class="warning">
 MIGRATION NOTE:<br>
 Stacked heads; insert something here!
 </aside>
+
+<aside class="error">
+MIGRATION NOTE:<br>
+Stacked heads; insert something here!
+</aside>
+
+>I'm a blockquote, `containing code`, hear me roar.
 
 
 #### <span class="jumptarget"> Auth Callback and Load Callback URIs </span>

--- a/source/includes/_api_registration.md
+++ b/source/includes/_api_registration.md
@@ -10,27 +10,10 @@ The app registration wizard requests a number of details that you may not know j
 
 ### <span class="jumptarget"> Technical Requirements </span>
 
-<aside class="notice">
-MIGRATION NOTE:<br>
-Stacked heads; insert something here!
-</aside>
-
-<aside class="success">
-MIGRATION NOTE:<br>
-Stacked heads; insert something here!
-</aside>
-
 <aside class="warning">
 MIGRATION NOTE:<br>
 Stacked heads; insert something here!
 </aside>
-
-<aside class="error">
-MIGRATION NOTE:<br>
-Stacked heads; insert something here!
-</aside>
-
->I'm a blockquote, `containing code`, hear me roar.
 
 
 #### <span class="jumptarget"> Auth Callback and Load Callback URIs </span>

--- a/source/includes/_api_registration.md
+++ b/source/includes/_api_registration.md
@@ -10,7 +10,7 @@ The app registration wizard requests a number of details that you may not know j
 
 ### <span class="jumptarget"> Technical Requirements </span>
 
-<aside class="warning">
+<aside class="notice">
 MIGRATION NOTE:<br>
 Stacked heads; insert something here!
 </aside>

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -34,7 +34,7 @@ $lang-select-bg: #292732;
 $lang-select-active-bg: $lang-select-bg; // feel free to change this to blue or something
 $lang-select-pressed-bg: $lang-select-bg; // color of language tab bg when mouse is pressed
 $main-bg: #ffffff;
-$aside-notice-bg: #DBE3FE;     /* Changed blue to shade matching BC 2016 branding */ 
+$aside-notice-bg: #f0f3fe;     /* Changed blue to tint matching BC 2016 branding */ 
 /* $aside-warning-bg: #F9F2E6;  Changed original salmon to orange; could be more vibrant */
 /* $aside-warning-bg: #fcf8f2;  Stencil orange, tried 7/19/16 */ 
 $aside-warning-bg: #F8F3D5;  /* Dustin's orange, applied 7/19/16 */ 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -536,7 +536,8 @@ html, body {
   code {
     /* background-color: rgba(0,0,0,0.05); */
     /* ^ Swapped out this indistinct dark gray, 6/8/16, for: */
-    background-color: #f5f5f5; /* "White smoke," matching Stencil docs */
+    /* background-color: #f5f5f5; */ /* "White smoke," matching Stencil docs */
+    /* background-color: transparent;
     /* Added 6/8/16 to color *inline* code text (*not* over a black code box) crimson, like Stencil site's: */
     color: #cc2255;
     padding: 3px;
@@ -891,7 +892,7 @@ img {
 }
 
 .content aside.warning::first-line {
-  color: #df8a13;
+  color: #ec971f;
   font-weight: bold;
   text-shadow: none;
 }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -574,7 +574,7 @@ html, body {
     &.warning {
       background-color: $aside-warning-bg;
       /* Added 7/19/16 for left rule, matching Stencil docs: */
-      border-left: 2px solid #df8a13;
+      border-left: 2px solid #ec971f;
       text-shadow: 0 1px 0 lighten($aside-warning-bg, 15%);
     }
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -745,6 +745,8 @@ body.twocolumn {
       /* width: 90%; */
       /* ^ Swapped 6/8/16 to trim code blocks' right margin to match surrounding body text; 80% is too wide: \/ */
       width: 75%;
+      /* New 7/20/16: Un-comment next line if we want to let long code lines wrap?: */
+      /* white-space: pre-wrap; */
     }
 
      /* Separated out "aside" 6/8/16, to conform its width to body-text width: */

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -535,8 +535,8 @@ html, body {
 
   code {
     /* background-color: rgba(0,0,0,0.05); */
-    /* ^ Swapped out this indistinct dark gray, 6/8/16, for: */
-    background-color: #f5f5f5; /* "White smoke," matching Stencil docs */
+    /* ^ Commented out this indistinct dark gray, 6/8/16, for: \/
+    background-color: transparent;
     /* Added 6/8/16 to color *inline* code text (*not* over a black code box) crimson, like Stencil site's: */
     color: #cc2255;
     padding: 3px;
@@ -891,7 +891,7 @@ img {
 }
 
 .content aside.warning::first-line {
-  color: #df8a13;
+  color: #ec971f;
   font-weight: bold;
   text-shadow: none;
 }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -539,7 +539,8 @@ html, body {
     background-color: transparent;
     /* Added 6/8/16 to color *inline* code text (*not* over a black code box) crimson, like Stencil site's: */
     color: #cc2255;
-    padding: 3px;
+    /* padding: 3px; */
+    padding: 2px;
     border-radius: 3px;
     @extend %break-words;
     @extend %code-font;

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -536,8 +536,7 @@ html, body {
   code {
     /* background-color: rgba(0,0,0,0.05); */
     /* ^ Swapped out this indistinct dark gray, 6/8/16, for: */
-    /* background-color: #f5f5f5; */ /* "White smoke," matching Stencil docs */
-    /* background-color: transparent;
+    background-color: #f5f5f5; /* "White smoke," matching Stencil docs */
     /* Added 6/8/16 to color *inline* code text (*not* over a black code box) crimson, like Stencil site's: */
     color: #cc2255;
     padding: 3px;
@@ -892,7 +891,7 @@ img {
 }
 
 .content aside.warning::first-line {
-  color: #ec971f;
+  color: #df8a13;
   font-weight: bold;
   text-shadow: none;
 }


### PR DESCRIPTION
On `aside.notice`, lightened blue background to a tint of BC 2016
branded blue – to make links, code, etc., readable against the bgd.

On `aside.warning`, corrected border-rule color to match bold-heading
color.