### PR TITLE
Peace at last for callouts

### DIFF
--- a/source/includes/_api_CRUD_categories.md
+++ b/source/includes/_api_CRUD_categories.md
@@ -226,5 +226,7 @@ Deletes all the categories in the store.
 >`DELETE /api/v2/categories`
 
 <aside class="warning">
-NOTE: The `DELETE` all categories operation will not succeed unless the store has zero products. If any products in the store belong to any categories, the entire operation will fail. Therefore, if you really want to delete all the categories of the store, you must first delete all of the products in the store.
+<span class="aside-warning-hd">NOTE:</span>
+
+The `DELETE` all categories operation will not succeed unless the store has zero products. If any products in the store belong to any categories, the entire operation will fail. Therefore, if you really want to delete all the categories of the store, you must first delete all of the products in the store.
 </aside>

--- a/source/includes/_api_CRUD_redirects.md
+++ b/source/includes/_api_CRUD_redirects.md
@@ -157,7 +157,8 @@ The following properties of the redirect are required. The request won’t be fu
 *   forward
 
 <aside class="notice">
-NOTES: The <code>path</code>, <code>forward.type</code>, and <code>forward.ref</code> fields of an existing redirect can be updated.
+<span class="aside-notice-hd">NOTES:</span> 
+The <code>path</code>, <code>forward.type</code>, and <code>forward.ref</code> fields of an existing redirect can be updated.
 </aside>
 
 

--- a/source/includes/_api_approval-requirements.md
+++ b/source/includes/_api_approval-requirements.md
@@ -12,7 +12,8 @@ Our submission guidelines aim to protect the merchant experience, and to provide
 
 *   Apps must be production-ready and free of defects.
 <aside class="warning">
-NOTE: Install and test your app thoroughly prior to submission. Be sure to install and run your app inside of your sandbox store, as a draft area to conduct your tests.
+<span class="aside-warning-hd">NOTE:</span>
+Install and test your app thoroughly prior to submission. Be sure to install and run your app inside of your sandbox store, as a draft area to conduct your tests.
 </aside>
 
 *   Apps must function properly on all [supported browsers](/api/browsers), and must conform to the [user interface constraints](/api/v2/#ui-constraints) – including P3P policies as necessary, and no mixed content.
@@ -24,7 +25,7 @@ NOTE: Install and test your app thoroughly prior to submission. Be sure to insta
 *   Whenever possible, apps must use the API resources to auto-fill and obtain information rather than prompting the user. Apps requesting information that can be auto-filled will be rejected.
 
     <aside class="notice">
-    NOTE: You can obtain the store name, phone number, and other information from the <a href="/api/#store" target="_blank">Store&#160;Information</a> resource.
+    <span class="aside-notice-hd">NOTE:</span> You can obtain the store name, phone number, and other information from the <a href="/api/#store" target="_blank">Store&#160;Information</a> resource.
     </aside>
 
 *   The user ID and email address from the [OAuth flow](/api/load#process) should allow you to automatically log the merchant into any additional systems. Apps that provide the merchant with a single-sign-on experience are preferred.

--- a/source/includes/_api_callback.md
+++ b/source/includes/_api_callback.md
@@ -3,7 +3,8 @@
 A user at a store's Control Panel kicks off the installation or update sequence by clicking to install your app, or by clicking an installed app to update its scopes. BigCommerce redirects the user to the **Auth Callback URI** provided during [app registration](#registration). The **Auth Callback URI** must be publicly available, fully qualified, and served over TLS.
 
 <aside class="warning">
-NOTES: The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
+<span class="aside-warning-hd"> NOTES:</span>
+The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
 
 For security, Auth and Load callback should be handled server-side. If you are building a client-side application (such as an AngularJS Single Page App), you should handle Auth and Load callbacks outside that application. Use a separate service that accepts the Auth and Load callback requests, generates tokens, validates requests, and then redirects the user to your client-side app's entry point.
 </aside>
@@ -60,7 +61,8 @@ Upon receiving the `GET` request at your **Auth Callback URI**, your app should 
 
 ### <span class="jumptarget"> <a name="post-req"></a> Making the POST request </span>
 
-The `POST` request's primary purpose is to exchange the temporary access code for a permanent OAuth token. However, your app must pass a number of additional values to accomplish the exchange. Pass the parameters and their values inside the request body, using query parameters and URL-encoding. To achieve this, you must include the following HTTP header: `Content-Type: application/x-www-form-urlencoded`
+The `POST` request's primary purpose is to exchange the temporary access code for a permanent OAuth token. However, your app must pass a number of additional values to accomplish the exchange. Pass the parameters and their values inside the request body, using query parameters and URL-encoding. To achieve this, you must include the following HTTP header:    
+`Content-Type: application/x-www-form-urlencoded`
 
 Make the `POST` request to the following address: `https://login.bigcommerce.com/oauth2/token`.
 

--- a/source/includes/_api_load.md
+++ b/source/includes/_api_load.md
@@ -1,7 +1,8 @@
 ## <span class="jumptarget"> <a name="load"></a> Load, Uninstall, and User Removal Requests</span>
 
 <aside class="warning">
-MIGRATION NOTE: Stacked heads; insert something here!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Stacked heads; insert something here!
 </aside>
 
 ### <span class="jumptarget"> Introduction</span>
@@ -32,7 +33,8 @@ The remainder of this entry discusses:
 Once your app has been installed, the store owner or user can click its icon in the Control Panel to launch it. This causes BigCommerce to send a **GET** request to the **Load Callback URI** that you provided. In a production environment, the **Load Callback URI** must be publicly available, fully qualified, and served over TLS/SSL.
 
 <aside class="warning">
-NOTES: The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
+<span class="aside-warning-hd">NOTES:</span>
+The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
 
 For security, Auth and Load callback should be handled server-side. If you are building a client-side application (such as an AngularJS Single Page App), you should handle Auth and Load callbacks outside that application. Use a separate service that accepts the Auth and Load callback requests, generates tokens, validates requests, and then redirects the user to your client-side app's entry point.
 </aside>
@@ -64,7 +66,8 @@ Host: app.example.com
 Upon receiving the **GET** request, your app will need to [process the signed payload](#process).
 
 <aside class="notice">
-NOTE: Any HTML that you return in your response will not be rendered.
+<span class="aside-notice-hd">NOTE:</span>
+Any HTML that you return in your response will not be rendered.
 </aside>
 
 
@@ -80,13 +83,15 @@ Host: app.example.com
 Upon receiving the **GET** request, your app will need to [process the signed payload](#process).
 
 <aside class="notice">
-NOTE: Any HTML that you return in your response will not be rendered.
+<span class="aside-notice-hd">NOTE:</span>
+Any HTML that you return in your response will not be rendered.
 </aside>
 
 ### <span class="jumptarget"> <a name="process"></a> Processing the signed payload</span>
 
 <aside class="warning">
-MIGRATION NOTE: Stacked heads; insert something here!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Stacked heads; insert something here!
 </aside>
 
 #### <span class="jumptarget"> <a name="process"></a> Splitting and decoding the signed payload</span>
@@ -110,7 +115,8 @@ To decode the signed payload, complete the following steps:
 To verify the payload, you need to sign the payload using your client secret, and confirm that it matches the signature that was sent in the request.
 
 <aside class="warning">
-NOTE: To limit the vulnerability of your app to <a href="http://codahale.com/a-lesson-in-timing-attacks/" target="_blank">timing attacks</a>, we recommend using a constant time string comparison function rather than the equality operator to check that the signatures match.
+<span class="aside-warning-hd">NOTE:</span>
+To limit the vulnerability of your app to <a href="http://codahale.com/a-lesson-in-timing-attacks/" target="_blank">timing attacks</a>, we recommend using a constant time string comparison function rather than the equality operator to check that the signatures match.
 </aside>
 
 ##### <span class="jumptarget"> Examples</span>
@@ -138,7 +144,8 @@ function verifySignedRequest($signedRequest)
 ```
 
 <aside class="notice">
-NOTE: <code>!hash_equals</code> is available in PHP 5.6 and later. If you are running an older version of PHP, pull in a compatibility library such as the following: <a href="https://packagist.org/packages/realityking/hash_equals" target="_blank">https://packagist.org/packages/realityking/hash_equals</a>. BigCommerce's sample app <NOBR><a href="https://github.com/bigcommerce/hello-world-app-php-silex" target="_blank">hello-world-app-php-silex app</a></nobr> does this automatically.
+<span class="aside-notice-hd">NOTE:</span> 
+<code>!hash_equals</code> is available in PHP 5.6 and later. If you are running an older version of PHP, pull in a compatibility library such as the following: <a href="https://packagist.org/packages/realityking/hash_equals" target="_blank">https://packagist.org/packages/realityking/hash_equals</a>. BigCommerce's sample app <NOBR><a href="https://github.com/bigcommerce/hello-world-app-php-silex" target="_blank">hello-world-app-php-silex app</a></nobr> does this automatically.
 </aside>
 
 *   [Ruby](#strcmp-ruby)
@@ -176,7 +183,8 @@ end
 #### <span class="jumptarget" id="Identifying"> Processing the JSON object</span>
 
 <aside class="warning">
-MIGRATION NOTE: Stacked heads; insert something here!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Stacked heads; insert something here!
 </aside>
 
 ##### <span class="jumptarget"> Introduction</span>

--- a/source/includes/_api_registration.md
+++ b/source/includes/_api_registration.md
@@ -11,7 +11,7 @@ The app registration wizard requests a number of details that you may not know j
 ### <span class="jumptarget"> Technical Requirements </span>
 
 <aside class="notice">
-MIGRATION NOTE:<br>
+<span class="aside-notice-hd">MIGRATION NOTE:</span>
 Stacked heads; insert something here!
 </aside>
 
@@ -21,7 +21,8 @@ Stacked heads; insert something here!
 You must have an [Auth Callback URI](#installation) and a [Load Callback URI](#load_request) to register your app.
 
 <aside class="notice">
-NOTE: Because the <b>Auth Callback URI</b> and <b>Load Callback URI</b> requests originate from the browser and not from BigCommerce, you can use non–publicly-available URIs and a self-signed certificate for a quick start. However, you must switch to – and test your app with – a publicly available <b>Auth Callback URI</b> and <b>Load Callback URI</b> before submitting your app for consideration in the App Store.
+<span class="aside-notice-hd">NOTE:</span>
+Because the <b>Auth Callback URI</b> and <b>Load Callback URI</b> requests originate from the browser and not from BigCommerce, you can use non–publicly-available URIs and a self-signed certificate for a quick start. However, you must switch to – and test your app with – a publicly available <b>Auth Callback URI</b> and <b>Load Callback URI</b> before submitting your app for consideration in the App Store.
 </aside>
 
 #### <span class="jumptarget"> Uninstall callback (optional) </span>
@@ -52,7 +53,8 @@ The following procedure takes you through the minimum number of steps to success
 2.  In the resulting login page, provide your sandbox store credentials.
 
 <aside class="notice">
-NOTE: These must be the credentials of the owner of the store where you plan to install your draft app.
+<span class="aside-notice-hd">NOTE:</span>
+These must be the credentials of the owner of the store where you plan to install your draft app.
 </aside>
 
 3.  Click `My Apps`.

--- a/source/includes/_api_root.md
+++ b/source/includes/_api_root.md
@@ -1,7 +1,8 @@
 # <span class="jumptarget"> Building OAuth Apps </span>
 
 <aside class="notice">
-tK: We still need to migrate introductory content here. Should also add something explaining the new terminology "OAuth Apps" versus "Basic-Auth Apps."
+<span class="aside-notice-hd">tK:</span>
+We still need to migrate introductory content here. Should also add something explaining the new terminology "OAuth Apps" versus "Basic-Auth Apps."
 </aside>
 
 ## <span class="jumptarget"> App Installation and Update Sequence </span>
@@ -11,7 +12,8 @@ tK: We still need to migrate introductory content here. Should also add somethin
 A user at a store's Control Panel kicks off the installation or update sequence by clicking to install your app, or by clicking an installed app to update its scopes. BigCommerce redirects the user to the **Auth Callback URI** provided during [app registration](/api/registration). The **Auth Callback URI** must be publicly available, fully qualified, and served over TLS.
 
 <aside class="warning">
-NOTES: The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
+<span class="aside-warning-hd">NOTES:</span>
+The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
 
 For security, Auth and Load callback should be handled server-side. If you are building a client-side application (such as an AngularJS Single Page App), you should handle Auth and Load callbacks outside that application. Use a separate service that accepts the Auth and Load callback requests, generates tokens, validates requests, and then redirects the user to your client-side app's entry point.
 </aside>
@@ -248,7 +250,8 @@ The remainder of this page discusses:
 Once your app has been installed, the store owner or user can click its icon in the Control Panel to launch it. This causes BigCommerce to send a **GET** request to the **Load Callback URI** that you provided. In a production environment, the **Load Callback URI** must be publicly available, fully qualified, and served over TLS/SSL.
 
 <aside class="warning">
-NOTES: The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
+<span class="aside-warning-hd">NOTES:</span>
+The request comes from the client browser, rather than directly from BigCommerce. This allows you to use a non-publicly-available <b>Auth Callback URI</b> while testing your app.<br><br>
 
 For security, Auth and Load callback should be handled server-side. If you are building a client-side application (such as an AngularJS Single Page App), you should handle Auth and Load callbacks outside that application. Use a separate service that accepts the Auth and Load callback requests, generates tokens, validates requests, and then redirects the user to your client-side app's entry point.
 </aside>
@@ -280,7 +283,8 @@ Host: app.example.com
 Upon receiving the **GET** request, your app will need to [process the signed payload](#process).
 
 <aside class="notice">
-NOTE: Any HTML that you return in your response will not be rendered.
+<span class="aside-notice-hd">NOTE:</span>
+Any HTML that you return in your response will not be rendered.
 </aside>
 
 
@@ -296,7 +300,8 @@ Host: app.example.com
 Upon receiving the **GET** request, your app will need to [process the signed payload](#process).
 
 <aside class="notice">
-NOTE: Any HTML that you return in your response will not be rendered.
+<span class="aside-notice-hd">NOTE:</span>
+Any HTML that you return in your response will not be rendered.
 </aside>
 
 ### <span class="jumptarget"> Processing the signed payload </span>
@@ -322,7 +327,9 @@ To decode the signed payload, complete the following steps:
 To verify the payload, you need to sign the payload using your client secret, and confirm that it matches the signature that was sent in the request.
 
 <aside class="warning">
-NOTE: To limit the vulnerability of your app to <a href="http://codahale.com/a-lesson-in-timing-attacks/">timing attacks</a>, we recommend using a constant time string comparison function rather than the equality operator to check that the signatures match.
+
+<span class="aside-warning-hd">NOTE:</span>
+To limit the vulnerability of your app to <a href="http://codahale.com/a-lesson-in-timing-attacks/">timing attacks</a>, we recommend using a constant time string comparison function rather than the equality operator to check that the signatures match.
 </aside>
 
 ##### <span class="jumptarget"> Examples </span>
@@ -349,7 +356,8 @@ function verifySignedRequest($signedRequest)
 ```
 
 <aside class="notice">
-NOTE: <code>!hash_equals</code> is available in PHP 5.6 and later. If you are running an older version of PHP, pull in a compatibility library such as the following: <a href="https://packagist.org/packages/realityking/hash_equals">https://packagist.org/packages/realityking/hash_equals</a>. BigCommerce's sample app <NOBR><a href="hello-world-app-php-silex app">https://github.com/bigcommerce/hello-world-app-php-silex</a></nobr> does this automatically.
+<span class="aside-notice-hd">NOTE:</span>
+<code>!hash_equals</code> is available in PHP 5.6 and later. If you are running an older version of PHP, pull in a compatibility library such as the following: <a href="https://packagist.org/packages/realityking/hash_equals">https://packagist.org/packages/realityking/hash_equals</a>. BigCommerce's sample app <NOBR><a href="hello-world-app-php-silex app">https://github.com/bigcommerce/hello-world-app-php-silex</a></nobr> does this automatically.
 </aside>
 
 *   [Ruby](#strcmp-ruby)
@@ -426,7 +434,8 @@ Interpreting the user information varies as follows.
 
 # <span class="jumptarget"> Building Basic-Auth Apps </span>
 
-<aside class="notice">
-tK: We still need to migrate content here. 
+<aside class="warning">
+<span class="aside-warning-hd">MIGRATION NOTE – TK:</span>
+We still need to migrate content here. 
 </aside>
 

--- a/source/includes/_api_root_basic_auth.md
+++ b/source/includes/_api_root_basic_auth.md
@@ -1,5 +1,6 @@
 # <span class="jumptarget"> Building Basic-Auth Apps </span>
 
-<aside class="notice">
-tK: We still need to migrate content here. 
+<aside class="warning">
+<span class="aside-warning-hd">MIGRATION NOTE – tK:</span>
+We still need to migrate this section's whole content! 
 </aside>

--- a/source/includes/_api_root_oauth.md
+++ b/source/includes/_api_root_oauth.md
@@ -1,7 +1,8 @@
 # <span class="jumptarget"> <a name="using-oauth-intro"></a> Building OAuth Apps </span>
 
-<aside class="notice">
-tK: We still need to migrate introductory content here. Should also add something explaining the new terminology "OAuth Apps" versus "Basic-Auth Apps."
+<aside class="warning">
+<span class="aside-warning-hd">MIGRATION NOTE – tK:</span>
+We still need to migrate introductory content here. Should also add something explaining the new terminology "OAuth Apps" versus "Basic-Auth Apps."
 </aside>
 
 ## <span class="jumptarget"> About Single-Click Apps </span>

--- a/source/includes/_api_scopes.md
+++ b/source/includes/_api_scopes.md
@@ -5,7 +5,8 @@ The following table identifies the name used for each OAuth scope in the My Apps
 All OAuth scopes except `default` have `read_only` scopes that allow only `GET` and `HEAD` requests.
 
 <aside class="warning">
-MIGRATION NOTE: All links in the right column need to be re-set!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+ All links in the right column need to be re-set!
 </aside>
 
 | Scope GUI Name | Scope Strings | Resources |

--- a/source/includes/_api_webhooks_getting_started.md
+++ b/source/includes/_api_webhooks_getting_started.md
@@ -10,7 +10,8 @@ For example, you might build an app that needs to know when:
 
 
 <aside class="notice">
-NOTES: Webhooks differ from the rest of the Stores API as follows:
+<span class="aside-notice-hd">NOTES:</span>
+Webhooks differ from the rest of the Stores API as follows:
   <ul>
 	<li>OAuth is required; basic authentication is not supported.</li>
 	<li>Self-signed certificates are not supported.</li>
@@ -38,7 +39,8 @@ Before you can send any requests or receive any responses, you will need the fol
 *   **Valid TLS/SSL setup**: verify your setup at the following site: [https://sslcheck.globalsign.com](https://sslcheck.globalsign.com).
 
 <aside class="notice">
-NOTES: Any one of the following will cause a connection failure:
+<span class="aside-notice-hd">NOTES:</span>
+Any one of the following will cause a connection failure:
   <ul>
 	<li>Hostname/DNS mismatch.</li>
 	<li>Self-signed certificate.</li>
@@ -50,7 +52,8 @@ NOTES: Any one of the following will cause a connection failure:
 ### <span class="jumptarget"> Creating webhooks </span>
 
 <aside class="warning">
-MIGRATION NOTE: Stacked heads; insert something here!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Stacked heads; insert something here!
 </aside>
 
 #### <span class="jumptarget"> Sending the POST request </span>
@@ -59,7 +62,7 @@ To create a webhook, send a `POST` request to the `hooks` resource, including:
 
 *   As the `scope` value, the event for which you would like to receive notification. See next section for the list of possibilities.
 <aside class="notice">
-NOTE: Wildcards are supported for <code>scope</code>.
+<span class="aside-notice-hd">NOTE:</span> Wildcards are supported for <code>scope</code>.
 </aside>
 *   As the `destination` value, the callback's fully qualified URI.
 
@@ -70,7 +73,8 @@ NOTE: Wildcards are supported for <code>scope</code>.
 An `HTTP 201` response indicates that the webhook was set successfully.
 
 <aside class="warning">
-MIGRATION NOTE: Links above and below here still need to be set, after Slate file refactoring.
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Links above and below here still need to be set, after Slate file refactoring.
 </aside>
 
 Please review the [hooks resource](https://developer.bigcommerce.com/api/stores/v2/webhooks#create-hook) and [webhook object](https://developer.bigcommerce.com/api/objects/v2/webhook) pages for more details.
@@ -97,7 +101,8 @@ Please review the [hooks resource](https://developer.bigcommerce.com/api/stores/
 You'll need to build an application and configure your server to receive the callback, which we send when events are triggered.
 
 <aside class="notice">
-NOTE: It can take up to one minute for BigCommerce to start sending <code>POST</code> requests to your callback URI following the creation of a webhook.
+<span class="aside-notice-hd">NOTE:</span>
+It can take up to one minute for BigCommerce to start sending <code>POST</code> requests to your callback URI following the creation of a webhook.
 </aside>
 
 #### <span class="jumptarget"> Lightweight callback payload </span>
@@ -160,7 +165,8 @@ Using your OAuth access token, send a [DELETE request](/api/stores/v2/webhooks#d
 ### <span class="jumptarget"> Troubleshooting </span>
 
 <aside class="warning">
-MIGRATION NOTE: Stacked heads; insert something here!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Stacked heads; insert something here!
 </aside>
 
 #### <span class="jumptarget"> Not receiving the POST requests to my callback URI </span>
@@ -191,7 +197,8 @@ After sending a POST request to create a webhook, you should get an HTTP 201 bac
 ### <span class="jumptarget"> Tools for Debugging and Testing Webhooks </span>
 
 <aside class="warning">
-MIGRATION NOTE: Stacked heads; insert something here!
+<span class="aside-warning-hd">MIGRATION NOTE:</span>
+Stacked heads; insert something here!
 </aside>
 
 ##### <span class="jumptarget"> RequestBin </span>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -876,62 +876,34 @@ img {
 // Styles for asides' bold headings – added 7/19/16;
 // Changed 7/21/16 to an optional <span> style. 
 // So we no longer enforce a heading in each callout 
-// – too confining and too inconsistent.
-// Each icon independently has the same color, 
-// so we can have colored icons a-la-carte.
+// – that was too confining, and too inconsistent. 
+// Also, the spans allow sideheads.
+// Each icon independently takes the same color, so we 
+// can has colored icons a-la-carte without colored heads.
 
-.content aside.notice::first-line {
+.aside-notice-hd {
   color: #4E75F8;
   font-weight: bold;
   text-shadow: none;
 }
 
-.content aside.success::first-line {
+.aside-success-hd {
   color: #50af51;
   font-weight: bold;
   text-shadow: none;
 }
 
-.content aside.warning::first-line {
+.aside-warning-hd {
   color: #ec971f;
   font-weight: bold;
   text-shadow: none;
 }
 
-.content aside.error::first-line {
+.aside-error-hd {
   color: #D9534F;
   font-weight: bold;
   text-shadow: none;
 }
-
-
-/* .content aside.notice::first-line {
-  color: #4E75F8;
-  font-weight: bold;
-  text-shadow: none;
-  display: block;
-}
-
-.content aside.success::first-line {
-  color: #50af51;
-  font-weight: bold;
-  text-shadow: none;
-  display: block;
-}
-
-.content aside.warning::first-line {
-  color: #ec971f;
-  font-weight: bold;
-  text-shadow: none;
-  display: block;
-}
-
-.content aside.error::first-line {
-  color: #D9534F;
-  font-weight: bold;
-  text-shadow: none;
-  display: block;
-} */
 
 
 @import 'custom';

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -607,19 +607,19 @@ html, body {
     color: #4E75F8;
   }
 
+  aside.success:before {
+    @extend %icon-ok-sign;
+    color: #50af51;
+  }
+
   aside.warning:before {
     @extend %icon-exclamation-sign;
-    color: #df8a13;
+    color: #ec971f;
   }
 
   aside.error:before {
     @extend %icon-exclamation-sign;
     color: #D9534F;
-  }
-
-  aside.success:before {
-    @extend %icon-ok-sign;
-    color: #50af51;
   }
 
 
@@ -873,13 +873,14 @@ img {
 ////////////////////////////////////////////////////////////////////////////////
 // Callout HEADING Styles
 ////////////////////////////////////////////////////////////////////////////////
-// Styles for asides' bold first lines – added 7/19/16.
-// These enforce a heading in each callout, which must end with <br>. 
-// If that's too confining, could change to an optional <span> style.
+// Styles for asides' bold headings – added 7/19/16;
+// Changed 7/21/16 to an optional <span> style. 
+// So we no longer enforce a heading in each callout 
+// – too confining and too inconsistent.
 // Each icon independently has the same color, 
 // so we can have colored icons a-la-carte.
 
- .content aside.notice::first-line {
+.content aside.notice::first-line {
   color: #4E75F8;
   font-weight: bold;
   text-shadow: none;
@@ -902,6 +903,35 @@ img {
   font-weight: bold;
   text-shadow: none;
 }
+
+
+/* .content aside.notice::first-line {
+  color: #4E75F8;
+  font-weight: bold;
+  text-shadow: none;
+  display: block;
+}
+
+.content aside.success::first-line {
+  color: #50af51;
+  font-weight: bold;
+  text-shadow: none;
+  display: block;
+}
+
+.content aside.warning::first-line {
+  color: #ec971f;
+  font-weight: bold;
+  text-shadow: none;
+  display: block;
+}
+
+.content aside.error::first-line {
+  color: #D9534F;
+  font-weight: bold;
+  text-shadow: none;
+  display: block;
+} */
 
 
 @import 'custom';


### PR DESCRIPTION
Changed all `aside*` heads from `::first-line` pseudo-elements to
optional `span`'s. Corrected icons’ color for `aside.warning:before`. Retagged some `aside` paragraphs to verify good results. This might really be final re-styling for callouts.