### PR TITLE
Table+content updates

### DIFF
--- a/source/includes/_api_load.md
+++ b/source/includes/_api_load.md
@@ -209,18 +209,30 @@ Interpreting the user information varies as follows.
 
 | Name | Data Type | Value Description |
 | --- | --- | --- |
-| id | integer | Unique identifier for the user. |
-| email | string | The user’s email address. |
-| store_hash | string | Unique identifier of the store. |
+| user.id | integer | Unique identifier for the user who initiated the callback. |
+| user.email | string | Email address of the user who initiated the callback. |
+| owner.id | integer | Unique identifier for the user listed as the store owner. |
+| owner.email | string | Email address of the user listed as the store owner. |
+| context | string | The context value is part of the API path for this store and includes the store_hash. |
+| store_hash | string |Unique identifier for the store. |
+| timestamp | float | The time (in Unix time) when the callback was generated. |
 
 ##### <span class="jumptarget"> JSON Example</span>
 
 ```json
 {
-  "user": {
-	"id": 24654,
-	"email": "user@mybigcommerce.com"
-  },
-  "store_hash": "STORE_HASH"
+    "user":
+         {
+        "id":9128,
+        "email":"user@mybigcommerce.com"
+     },
+     "owner":
+          {
+         "id":9128,
+         "email":"user@mybigcommerce.com"
+     },
+     "context":"stores/z4zn3wo",
+     "store_hash":"z4zn3wo",
+     "timestamp":1469823892.9123988
 }
 ```

--- a/source/includes/_api_objects_product_configurable_field.md
+++ b/source/includes/_api_objects_product_configurable_field.md
@@ -2,7 +2,7 @@
 
 Configurable fields associated with a product.
 
-## <span class="jumptarget"> Configureable Field - Properties </span>
+## <span class="jumptarget"> Configurable Fields – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/source/includes/_api_objects_product_googleproductsearch.md
+++ b/source/includes/_api_objects_product_googleproductsearch.md
@@ -1,19 +1,19 @@
 # <span class="jumptarget"> Google Product Search Mappings </span>
 
-## <span class="jumptarget"> Google Product Search Mapping Object - Properties </span>
+## <span class="jumptarget"> Google Product Search Mapping Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |
-| enabled | boolean |
-| product_id | int |
-| category_id | int |
-| custom_item | boolean |
-| global_trade_item_number | string |
-| manufacturer_part_number | string |
-| gender | string |
-| age_group | string |
-| color | string |
-| size | string |
-| material | string |
-| pattern | pattern |
-| google_shopping_product_category_path | string |
+| enabled | boolean | [Descriptions are pending – will be added here]   |
+| product_id | int |  |
+| category_id | int |  |
+| custom_item | boolean |  |
+| global_trade_item_number | string |  |
+| manufacturer_part_number | string |  |
+| gender | string |  |
+| age_group | string |  |
+| color | string |  |
+| size | string |  |
+| material | string |  |
+| pattern | pattern |  |
+| google_shopping_product_category_path | string |  |

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -906,6 +906,17 @@ img {
 }
 
 
+// From Nate, 7/30/16 – forces all tables' borders to consistent width.
+// But check whether it distorts column widths, outside of edge cases:
+
+.content table {
+    display: table !important;
+    margin-left: 28px;
+    width: 75% !important;
+    min-width: initial !important;
+}
+
+
 @import 'custom';
 @import 'page';
 @import 'buttons';


### PR DESCRIPTION
* Adds Nate’s CSS to create uniform table-border widths.

* Stray content updates/fixes that arrived at the same time.

* Good, clean point to merge this back in.

Here's the golden CSS, from commit below:
```
.content table {
display: table !important;
margin-left: 28px;
width: 75% !important;
min-width: initial !important;
}
```