### PR TITLE
TOC/search design tweaks

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -12,7 +12,9 @@
 
   var makeToc = function() {
     global.toc = $("#toc").tocify({
-      selectors: 'h1, h2, h3, h4, h5, h6, h7',
+      /* selectors: 'h1, h2, h3, h4, h5, h6, h7', */
+      // ^ Swapped 8/4/16: Try limiting left-nav depth to 3 levels \/:
+      selectors: 'h1, h2, h3',
       extendPage: false,
       theme: 'none',
       smoothScroll: false,

--- a/source/stylesheets/_navbar.scss
+++ b/source/stylesheets/_navbar.scss
@@ -135,7 +135,9 @@ header {
 
 .top-bar .name img,
 [top-bar] .name img {
-    width: 52px
+    width: 52px;
+    // Added 8/4/16 to left-align top BC logo:
+    margin-left: -105px;
 }
 
 .top-bar .toggle-topbar,

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -628,7 +628,8 @@ html, body {
     margin: -2px;
     border-radius: 4px;
     border: 1px solid #F7E633;
-    text-shadow: 1px 1px 0 #666;
+    // Commented out 8/4/16 to remove embossed effect:
+    /* text-shadow: 1px 1px 0 #666; */
     background: linear-gradient(to top left, #F7E633 0%, #F1D32F 100%);
   }
 }


### PR DESCRIPTION
Merging 3 small style changes: Limited TOC/left nav to 3 head levels; left-aligned BC logo; & removed shadow-text effect from search hits.