### PR TITLE
Added `%%GLOBAL_CustomerGroupId%%` to Themes > Global Variables

### DIFF
--- a/source/includes/_themes_global_variables.md
+++ b/source/includes/_themes_global_variables.md
@@ -86,6 +86,7 @@ The list below is sorted by the number of times that the Blueprint base theme re
 | `%%GLOBAL_HideCreditCardError%%` | . |
 | `%%GLOBAL_CustomerName%%` | . |
 | `%%GLOBAL_CustomerEmail%%` | . |
+| `%%GLOBAL_CustomerGroupId%%` | . |
 | `%%GLOBAL_ReCaptchaAPIKeyPublic%%` | . |
 | `%%GLOBAL_SearchId%%` | . |
 | `%%GLOBAL_OrderComments%%` | . |


### PR DESCRIPTION
At Adam Ferenzi’s request. Can’t match on Contentful because of
https://jira.bigcommerce.com/browse/API-216 blockage.