### PR TITLE
4 button row re-skin

### DIFF
--- a/source/layouts/apitwocolumn.erb
+++ b/source/layouts/apitwocolumn.erb
@@ -100,10 +100,10 @@ under the License.
           <a href="/api/" class="btn btn-default" data-page-name="home">Basics</a>
           <a href="/api/v2/" class="btn btn-default" data-page-name="V2">V2</a>
           <a href="/api/v3/" class="btn btn-default" data-page-name="V3">V3</a>
-          <%# <a href="/themes/" class="btn btn-default" data-page-name="Themes">Themes</a> %>
+          <a href="/themes/" class="btn btn-default" data-page-name="Themes">Themes</a>
         </div>
-      <%# 2nd button row, added 8/17/16: %>
-      </div>  
+      <%# 2nd button row, tried 8/17/16, removed 8/18/16 as excessive: %>
+      <%# </div>  
       <div class="clear"></div>
       <div class="api-nav">
         <div class="nav-label">Themes</div>
@@ -111,8 +111,8 @@ under the License.
           <a href="/themes/" class="btn btn-default" data-page-name="themes">About</a>
           <a href="/themes/blueprint/" class="btn btn-default" data-page-name="Blueprint">Blueprint</a>
           <a href="https://stencil.bigcommerce.com/docs/what-is-stencil" class="btn btn-default" data-page-name="Stencil">Stencil</a>
-        </div>
-      <%# :End 2nd button row, added 8/17/16 %>
+        </div> %>
+      <%# :End 2nd button row, tried 8/17/16, removed 8/18/16 %>
         <div class="clear"></div>
       <% if language_tabs %>
         <div class="lang-selector">

--- a/source/stylesheets/_buttons.scss
+++ b/source/stylesheets/_buttons.scss
@@ -213,7 +213,7 @@
     display: inline-block;
     /* padding: 9px 11px; */
     /* ^ Swapped 8/15/16 to avoid de-centering button labels (left/right: 6px);
-          then trimmed to 0 on 8/17/16 to fit "Blueprint" label: \/ */
+          then trimmed to 0 on 8/17/16 to fit Themes labels: \/ */
     padding: 9px 0px 9px 0px;
     margin-bottom: 0;
     font-size: 14px;
@@ -243,13 +243,16 @@
     /* margin-left: 36px; */
     /* ^ Swapped 8/15/16 to left-align whole left nav \/: */
     margin-left: 8px;
-    margin-right: 32px
+    /* Hacked 8/18/16 to fit 4th button across: */
+    width: 225px;
 }
 
 .btn-group>.btn {
     position: relative;
     float: left;
-    width: 33%
+    /* width: 33% */
+    /* ^ Swapped 8/18/16 to fit 4th button across \/: */
+    width: 25%
 }
 
 .btn-group>.btn:first-child:not(:last-child):not(.language-dropdown) {

--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -206,9 +206,7 @@ table td:nth-child(3) {
   margin-bottom: 12px;
   font-size: 15px;
   font-weight: normal;
-  /* margin-top: 32px; */
-    /* ^ Swapped 8/17/16 – shallower for 2nd top-left button row \/: */
-  margin-top: 8px;
+  margin-top: 32px;
 }
 
 .clear {

--- a/source/themes/blueprint/index.html.md
+++ b/source/themes/blueprint/index.html.md
@@ -25,7 +25,28 @@ search: true
 
 # Blueprint Themes
 
-Getting Started with Blueprint
+## Getting Started with Blueprint
+
+If you, Skipper, prefer not to navigate large tiles like those below – then here is an austere bullet list of things you can do with Blueprint themes. It is inspired by [this Smooch landing page](http://docs.smooch.io/javascript/#welcome) that Nate suggested as a model.
+
+We're all developers here, so please feel free to iterate on this as a prototype for other landing pages that essentially ask, "Do you want to take the red pill or the blue pill?":  
+
+* [Layouts](/themes/blueprint/layouts)  
+  
+	Layout templates provide the base HTML structure that wraps storefront page content. Each layout file corresponds to a specific page, and typically contains references to individual panels to be shown on a page.
+
+* [Panels](/themes/blueprint/panels)  
+
+	Panels provide reusable blocks of content. Panels are contained in div tags that generally define a page's left, center, or right column. Panels can contain content, or can generate content dynamically.
+
+* [Snippets](/themes/blueprint/snippets)  
+ 
+	Snippets are templates containing a fragment of HTML that can be embedded multiple times on a page.	
+* Styles  
+ 
+	These are the theme's primary layout stylesheets, with styles.css being the core file.	
+	
+But wait: Perhaps you _are_ a fan of large tiles? Well then, Champ, be our guest. Please play Twister with these:	
 
 <section class=
     "block block--defaultScheme block--allViewport block--paddingTop block--twoColTextOverBg">

--- a/source/themes/index.html.md
+++ b/source/themes/index.html.md
@@ -7,7 +7,7 @@ toc_footers:
   - <a href='/api/'>API</a>
   - <a href='/themes/'>Themes</a>
   - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp;  Stencil Themes</a>
+  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp; Stencil Themes</a>
   - <a href='#'>Sign Up for a Developer Key</a>
   - <a href='http://goo.gl/forms/380FmYFlaJ05CL3q2'>Sign Up for the Developer Newsletter</a>
   - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>


### PR DESCRIPTION
Commented out 2nd row of Themes buttons, as too
intrusive. Added single “Themes” button in widened single row,
using several CSS hacks. If we like the general flow, tweak/refactor later.