### PR TITLE
Final "Basic Auth" copy edit

### DIFF
--- a/source/includes/_api_guides_curl_quickstart.md
+++ b/source/includes/_api_guides_curl_quickstart.md
@@ -1,6 +1,6 @@
 ## <span class="jumptarget" id="curl_quickstart"> cURL Quickstart Guide </span>
 
-This page provides some sample cURL commands for quick-start purposes. These use Basic Authentication. Before you can issue them, you must generate Basic Authentication credentials, following the steps discussed in the [Overview](/api#basic-auth). Once you have your Basic Authentication credentials, you can issue cURL commands as shown below.
+This section provides some sample cURL commands, for quickstart purposes. These use Basic Authentication, so before you can issue these commands, you must generate Basic Authentication credentials by following the steps discussed [here](/api#basic-auth). Once you have your Basic Authentication credentials, you can issue cURL commands as listed below.
 
 ```
     curl --request GET \
@@ -18,7 +18,9 @@ If the request is made using the `Authorization` header, you need to encode the 
 
 ### <span class="jumptarget"> Orders</span>
 
-#### <span class="jumptarget"> Get a list of orders from the store</span>
+Here are sample cURL commands to handle orders.
+
+#### <span class="jumptarget"> Get a List of Orders from the Store</span>
 
 ```
     curl --request GET \
@@ -28,7 +30,7 @@ If the request is made using the `Authorization` header, you need to encode the 
 
 By default, the API request returns only 50 orders. If you want to return all the orders from the store, you must use filters, as shown in the next example below.
 
-#### <span class="jumptarget"> Get all orders from the store</span>
+#### <span class="jumptarget"> Get All Orders from the Store</span>
 
 Use the `limit` and `page` filter parameters to get a data beyond what the default query returns. Note that 200 orders is the maximum returned per page:
 
@@ -38,7 +40,7 @@ Use the `limit` and `page` filter parameters to get a data beyond what the defau
     https://store.mybigcommerce.com/api/v2/orders.json?limit=200&page=1
 ```
 
-#### <span class="jumptarget"> Update an order</span>
+#### <span class="jumptarget"> Update an Order</span>
 
 Orders take many fields upon update requests. (For details, please see [this documentation](/api/v2/#update-an-order).) Here, we update an order using just the mandatory fields:
 
@@ -51,7 +53,7 @@ Orders take many fields upon update requests. (For details, please see [this doc
 ```
 
 
-#### <span class="jumptarget"> Get orders created since a certain date</span>
+#### <span class="jumptarget"> Get Orders Created since a Certain Date</span>
 
 You can use the `If-Modified-Since` header to request orders that have been created after a given date:
 
@@ -63,7 +65,7 @@ You can use the `If-Modified-Since` header to request orders that have been crea
     https://store.mybigcommerce.com/api/v2/orders.json
 ```
 
-#### <span class="jumptarget"> Get coupons associated with an order</span>
+#### <span class="jumptarget"> Get Coupons Associated with an Order</span>
 
 An order can contain coupons, which might be applied to the order to offer discounts to the customer. You can look at all the available coupons in an order as follows:
 
@@ -73,7 +75,7 @@ An order can contain coupons, which might be applied to the order to offer disco
     https://store.mybigcommerce.com/api/v2/orders/115/coupons.json
 ```
 
-#### <span class="jumptarget"> Create a shipment for an order</span>
+#### <span class="jumptarget"> Create a Shipment for an Order</span>
 
 You can create a shipment for an order via the [Orders > Create a Shipment](/api/v2/#create-a-shipment) endpoint. As an example, third-party shipping services can query orders from a store when the orders are created, and create shipments for those:
 
@@ -87,7 +89,9 @@ You can create a shipment for an order via the [Orders > Create a Shipment](/api
 
 ### <span class="jumptarget"> Products</span>
 
-#### <span class="jumptarget"> Get a list of products from the store</span>
+Here are sample cURL commands to handle products.
+
+#### <span class="jumptarget"> Get a List of Products from the Store</span>
 
 ```
     curl --request GET \
@@ -97,7 +101,7 @@ You can create a shipment for an order via the [Orders > Create a Shipment](/api
 
 By default, the API request returns only 50 products. If you want to return all the products from the store, you must use filters, as shown in the example below.
 
-#### <span class="jumptarget"> Get all products from the store</span>
+#### <span class="jumptarget"> Get All Products from the Store</span>
 
 Use the `limit` and `page` filter parameters to get data beyond what the default query returns. Note that a maximum of 200 products are returned per page:
 
@@ -107,7 +111,7 @@ Use the `limit` and `page` filter parameters to get data beyond what the default
     https://store.mybigcommerce.com/api/v2/products.json?limit=200&page=1
 ```
 
-#### <span class="jumptarget"> Create a product</span>
+#### <span class="jumptarget"> Create a Product</span>
 
 Products have many fields. For details on the product fields allowed as part of a `POST` request, please see [this page](/api/v2/#create-a-product).
 
@@ -121,7 +125,7 @@ Let's assume that we want to create a product using only the fields that are for
     https://store.mybigcommerce.com/api/v2/products.json
 ```
 
-#### <span class="jumptarget"> Update a product</span>
+#### <span class="jumptarget"> Update a Product</span>
 
 To update the product created above, you could use the following:
 
@@ -133,7 +137,7 @@ To update the product created above, you could use the following:
     https://store.mybigcommerce.com/api/v2/products/id.json
 ```
 
-#### <span class="jumptarget"> Search a product by SKU</span>
+#### <span class="jumptarget"> Search a Product by SKU</span>
 
 To search by a product SKU, we could use the following code. Remember that when a product has optionset/variations defined, and if the individual options have SKUs defined, then the product SKU is overriden by the option SKUs. Currently, there are two ways to search for SKUs: `GET /products?sku="something"` or `GET /products/skus?sku="something"`. The first call returns only product-level SKUs and not option-level SKUs.
 
@@ -145,7 +149,9 @@ To search by a product SKU, we could use the following code. Remember that when 
 
 ### <span class="jumptarget"> Coupons</span>
 
-#### <span class="jumptarget"> Get a list of coupons from the store</span>
+Here are sample cURL commands to handle coupons.
+
+#### <span class="jumptarget"> Get a List of Coupons from the Store</span>
 
 ```
     curl --request GET \
@@ -163,7 +169,7 @@ Coupons can be filtered by `code`, `type`, `name`, `min_id` and `max_id`. Withou
 
 For details on filter fields, please see the [Coupons resource](/api/v2#coupons).
 
-#### <span class="jumptarget"> Create a coupon</span>
+#### <span class="jumptarget"> Create a Coupon</span>
 
 Coupons can be created by a `POST` request on the coupons endpoint. For example, if we want to create a coupon to take 50% off an order, then our coupon will have `percentage_discount` as the type. The `applies_to` field is optional, and can be used to restrict the coupon to a set of products or categories. In the example shown below, the coupon is being restricted to a set of products:
 
@@ -175,7 +181,7 @@ Coupons can be created by a `POST` request on the coupons endpoint. For example,
     https://store.mybigcommerce.com/api/v2/coupons.json
 ```
 
-#### <span class="jumptarget"> Update a coupon</span>
+#### <span class="jumptarget"> Update a Coupon</span>
 
 Updating a coupon is almost similar to the Create example above, except that we work off an ID via a `PUT` request. For example, assume that we want to change the above coupon from a 50% to a 30% discount, and that the coupon ID is `15`. We can update the coupon using the following:
 
@@ -189,7 +195,9 @@ Updating a coupon is almost similar to the Create example above, except that we 
 
 ### <span class="jumptarget"> Option Sets</span>
 
-#### <span class="jumptarget"> Connect options to option sets</span>
+Here are sample cURL commands to handle option sets.
+
+#### <span class="jumptarget"> Connect Options to Option Sets</span>
 
 This is currently a four-step process.
 


### PR DESCRIPTION
”cURL QuickStart" copy edits: Changed subheads to title case; broke up stacked heads. This solidifies “Building Basic-Auth Apps” left nav. Still need to reset links within body text.