### PR TITLE
Changelog tweaks

### DIFF
--- a/source/includes/_changelog_2016.md
+++ b/source/includes/_changelog_2016.md
@@ -3,6 +3,17 @@
 
 ## <span class="jumptarget"> August </span>
 
+### Stencil custom templates now generally available
+
+All Stencil stores now have the option of assigning custom layout templates to product, category, and brand pages, and to static storefront pages like the store's home page.
+
+To enable custom templates, theme developers must author the pages, and the merchant (or another authorized store user) must assign page mappings. For details, please see [this developer documentation](https://stencil.bigcommerce.com/docs/custom-layout-templates) and [this mechant-oriented article](https://support.bigcommerce.com/articles/Public/Stencil-Custom-Templates).
+
+
+### Stencil Handlebars variables now accessible via footer scripts
+
+You can now reference Handlebars variables – and their corresponding [Stencil objects and properties](https://stencil.bigcommerce.com/docs/stencil-object-model) – in scripts injected into a store’s global footer. You access this feature through the control panel’s `Storefront Design > Design Options > Scripts` tab, as illustrated in [this Knowledge Base article](https://support.bigcommerce.com/articles/Public/Adding-Custom-Scripts-to-Stencil-Themes).
+
 
 ### Blog Posts documentation updated
 

--- a/source/stylesheets/_custom.scss
+++ b/source/stylesheets/_custom.scss
@@ -133,7 +133,9 @@
 
   h3, h4 {
     padding-top: 2%;
-    padding-bottom: 2%;
+    // Commented out 8/31/16, to removed exaggerated 
+    // spacing below Changelog topic heads: 
+    /* padding-bottom: 2%; */
   }
 }
 


### PR DESCRIPTION
Added 8/31/16 entries for Stencil custom templates (now GA) & Handlebars-in-footer.

Commented out extra spacing below changelog > h3, h4 styles.