### PR TITLE
Moved "Building Apps" to root

### DIFF
--- a/source/api/index.html.md
+++ b/source/api/index.html.md
@@ -23,6 +23,23 @@ includes:
   - api_media_types
   - api_webhooks_getting_started
   - api_clients
+  - api_root_oauth
+  - api_registration
+  - api_callback
+  - api_load
+  - api_multi-user
+  - api_ui_constraints
+  - api_scopes
+  - api_rate-limits_oauth
+  - api_approval-requirements
+  - api_completing_reg
+  - api_app_gallery
+  - api_sample_contract
+  - api_root_basic_auth
+  - api_legacy_basic_auth
+  - api_rate_limits_basic
+  - api_guides_curl_quickstart
+  - api_guides_oauth_transition
 
 search: true
 ---

--- a/source/api/index.html.md
+++ b/source/api/index.html.md
@@ -8,13 +8,12 @@ language_tabs:
 
 toc_footers:
   - <a href="/">Home</a>
-  - <a href='/api/v2/'>API</a>
-  - <a href='/themes/'>Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp;  Stencil Themes</a>
-  - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='#'>Sign Up for a Developer Key</a>
-  - <a href='http://goo.gl/forms/380FmYFlaJ05CL3q2'>Sign Up for the Developer Newsletter</a>
-  - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
 
 includes:
   - api
@@ -40,6 +39,10 @@ includes:
   - api_rate_limits_basic
   - api_guides_curl_quickstart
   - api_guides_oauth_transition
+  - api_browsers.md
+  - api_status_codes
+  - api_data_types
+  - api_faqs
 
 search: true
 ---

--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -53,8 +53,6 @@ includes:
   - api_CRUD_orders_shipments
   - api_objects_payment_method
   - api_CRUD_payments_methods
-  - api_objects_product
-  - api_CRUD_products
   - api_objects_brand
   - api_CRUD_brands
   - api_objects_product_discount_rule
@@ -75,6 +73,8 @@ includes:
   - api_CRUD_option_sets_options
   - api_objects_option_value
   - api_CRUD_options_values
+  - api_objects_product
+  - api_CRUD_products
   - api_objects_product_image
   - api_CRUD_products_images
   - api_objects_product_product_option

--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -55,41 +55,47 @@ includes:
   - api_CRUD_payments_methods
   - api_objects_product
   - api_CRUD_products
+  - api_objects_brand
+  - api_CRUD_brands
+  - api_objects_product_discount_rule
+  - api_CRUD_products_discount_rules
+  - api_objects_category
+  - api_CRUD_categories
+  - api_objects_product_configurable_field
+  - api_CRUD_products_configurable_fields
+  - api_objects_product_custom_field
+  - api_CRUD_products_custom_fields
+  - api_objects_product_googleproductsearch
+  - api_CRUD_products_googleproductsearch
   - api_objects_product_option
   - api_CRUD_products_options
-  - api_objects_option_value
-  - api_CRUD_options_values
   - api_objects_option_set
   - api_CRUD_option_sets
   - api_objects_option_set_option
   - api_CRUD_option_sets_options
+  - api_objects_option_value
+  - api_CRUD_options_values
   - api_objects_product_image
   - api_CRUD_products_images
-  - api_objects_product_rule
-  - api_CRUD_products_rules
+  - api_objects_product_product_option
+  - api_CRUD_products_product_options
   - api_objects_product_review
   - api_CRUD_products_reviews
-  - api_objects_sku
-  - api_CRUD_products_skus
-  - api_objects_product_custom_field
-  - api_CRUD_products_custom_fields
-  - api_objects_product_configurable_field
-  - api_CRUD_products_configurable_fields
-  - api_objects_product_discount_rule
-  - api_CRUD_products_discount_rules
-  - api_objects_product_googleproductsearch
-  - api_CRUD_products_googleproductsearch
+  - api_objects_product_rule
+  - api_CRUD_products_rules
   - api_objects_product_video
   - api_CRUD_products_videos
-  - api_objects_category
-  - api_CRUD_categories
-  - api_objects_brand
-  - api_CRUD_brands
-  - api_objects_tax_class
-  - api_CRUD_tax_classes
+  - api_objects_sku
+  - api_CRUD_products_skus
   - api_objects_shipping_method
   - api_CRUD_shipping_methods
   - api_objects_store_information
+  - api_CRUD_store_information
+  - api_CRUD_time
+  - api_objects_tax_class
+  - api_CRUD_tax_classes
+  - api_objects_webhook
+  - api_CRUD_webhooks
 
 search: true
 ---

--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -43,14 +43,16 @@ includes:
   - api_CRUD_orders_messages
   - api_objects_order_product
   - api_CRUD_orders_products
-  - api_objects_order_status
-  - api_CRUD_orders_statuses
   - api_objects_order_shipping_address
   - api_CRUD_orders_shipping_addresses
+  - api_objects_order_status
+  - api_CRUD_orders_statuses
   - api_objects_order_tax.md
   - api_CRUD_orders_taxes.md
   - api_objects_order_shipment
   - api_CRUD_orders_shipments
+  - api_objects_payment_method
+  - api_CRUD_payments_methods
   - api_objects_product
   - api_CRUD_products
   - api_objects_product_option
@@ -87,8 +89,6 @@ includes:
   - api_CRUD_tax_classes
   - api_objects_shipping_method
   - api_CRUD_shipping_methods
-  - api_objects_payment_method
-  - api_CRUD_payments_methods
   - api_objects_store_information
 
 search: true

--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -2,15 +2,6 @@
 title: BigCommerce API Documentation
 layout: "apitwocolumn"
 
-toc_footers:
-  - <a href="/">Home</a>
-  - <a href="/api/">API - Basics</a>
-  - <a href="/themes/">Themes</a>
-  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
-  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
-  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
-  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
-
 includes:
   - api_objects_blog_post
   - api_CRUD_blog_posts
@@ -99,6 +90,15 @@ includes:
   - api_status_codes
   - api_data_types
   - api_faqs
+
+toc_footers:
+  - <a href="/">Home</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
 
 search: true
 ---

--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -4,13 +4,12 @@ layout: "apitwocolumn"
 
 toc_footers:
   - <a href="/">Home</a>
-  - <a href='/api/v2/'>API - Getting Started</a>
-  - <a href='/themes/'>Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp;  Stencil Themes</a>
-  - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='#'>Sign Up for a Developer Key</a>
-  - <a href='http://goo.gl/forms/380FmYFlaJ05CL3q2'>Sign Up for the Developer Newsletter</a>
-  - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
 
 includes:
   - api_objects_blog_post
@@ -96,6 +95,10 @@ includes:
   - api_CRUD_tax_classes
   - api_objects_webhook
   - api_CRUD_webhooks
+  - api_browsers.md
+  - api_status_codes
+  - api_data_types
+  - api_faqs
 
 search: true
 ---

--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -13,23 +13,6 @@ toc_footers:
   - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
 
 includes:
-  - api_root_oauth
-  - api_registration
-  - api_callback
-  - api_load
-  - api_multi-user
-  - api_ui_constraints
-  - api_scopes
-  - api_rate-limits_oauth
-  - api_approval-requirements
-  - api_completing_reg
-  - api_app_gallery
-  - api_sample_contract
-  - api_root_basic_auth
-  - api_legacy_basic_auth
-  - api_rate_limits_basic
-  - api_guides_curl_quickstart
-  - api_guides_oauth_transition
   - api_objects_blog_post
   - api_CRUD_blog_posts
   - api_CRUD_blog_tags

--- a/source/api/v3/index.html.md
+++ b/source/api/v3/index.html.md
@@ -2,15 +2,20 @@
 title: BigCommerce API Documentation
 layout: "apitwocolumn"
 
+includes:
+  - api_browsers.md
+  - api_status_codes
+  - api_data_types
+  - api_faqs
+
 toc_footers:
   - <a href="/">Home</a>
-  - <a href='/api/v2/'>API - Getting Started</a>
-  - <a href='/themes/'>Themes</a>
-  - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp;  Stencil Themes</a>
-  - <a href='#'>Sign Up for a Developer Key</a>
-  - <a href='http://goo.gl/forms/380FmYFlaJ05CL3q2'>Sign Up for the Developer Newsletter</a>
-  - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
 
 search: true
 ---

--- a/source/changelog/index.html.md
+++ b/source/changelog/index.html.md
@@ -2,21 +2,22 @@
 title: BigCommerce API &amp; Theme Framework Changelog
 layout: "twocolumn"
 
-toc_footers:
-  - <a href="/">Home</a>
-  - <a href='/api/v2/'>API</a>
-  - <a href='/themes/'>Themes</a>
-  - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp;  Stencil Themes</a>
-  - <a href='#'>Sign Up for a Developer Key</a>
-  - <a href='http://goo.gl/forms/380FmYFlaJ05CL3q2'>Sign Up for the Developer Newsletter</a>
-  - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
-
 includes:
 - changelog_2016
 - changelog_2015
 - changelog_2014
 - changelog_2013
+
+toc_footers:
+  - <a href="/">Home</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
+
+
 
 search: true
 ---

--- a/source/includes/_api_CRUD_orders.md
+++ b/source/includes/_api_CRUD_orders.md
@@ -294,55 +294,60 @@ All "Notes," "KNOWN ISSUES," and "PRO TIPs" formatted as `>blockquote` in this `
 
 >PRO TIP: Abbreviated state names in shipping and billing addresses will prevent tax documents from being submitted to Avalara. Spell state names out in full to ensure successful Avalara tax document submissions. For example, supplying `CA` as a state name results in no tax document submission. Supplying `California` as a state name results in a successful submission.
 
-##### <span class="jumptarget"> Overriding Preset Values </span>
+#### <span class="jumptarget"> Overriding Preset Values </span>
 
 You can create overrides for calculated values such as product prices, subtotal and totals by sending a fixed value in the request. If values are not supplied for these properties, they will be automatically calculated based on the pre-set store values and tax rules.
 
-##### <span class="jumptarget"> Order Products </span>
+#### <span class="jumptarget"> Order Products </span>
 
 *   Existing products can be added to the order with a reference to their `product_id`.
 *   Custom products can be added to the order using the `products array`.
-*   If price is not specified, it will automatically pick up the price from the store’s product catalog, however you can override it via `price_inc_tax` and `price_ex_tax`.
-*   If `price_inc_tax` and `price_ex_tax` is specified, price and rulesets are ignored and the `price_inc_tax` or `price_ex_tax` are written to `base_price`, according to the store settings.
-*   When the store is subscribed to Avalara Premium, a value of `API Tax Override` is written to the `name` field of the order tax object.
-*   Tax will be calculated based on the tax rules specified in the store except in the case of automatic taxes, however you can optionally override the tax values by specifying `price_inc_tax` and `price_ex_tax` in both cases.
-*   For products which are configured to track stock, the quantity specified on the order will reduce the stock on hand. When there is not enough inventory to fulfill the order, it will be rejected with an ‘out of stock’ error code.
-*   For products which have min and max quantities specified in their settings, the API will honor these and reject orders appropriately.
-*   For products where product options are required, the API will validate these requirements to ensure the product options are specified.
+*   If price is not specified, it will automatically pick up the price from the store’s product catalog. However, you can override this via `price_inc_tax` and `price_ex_tax`.
+*   If `price_inc_tax` and `price_ex_tax` are specified, price and rulesets are ignored, and the `price_inc_tax` or `price_ex_tax` are written to `base_price` according to the store settings.
+*   When the store is subscribed to Avalara Premium, a value of `API Tax Override` is written to the Order Tax object's `name` field.
+*   Tax will be calculated based on the tax rules specified in the store, except in the case of automatic taxes. However, in both cases, you can optionally override the tax values by specifying `price_inc_tax` and `price_ex_tax`.
+*   For products that are configured to track stock, the quantity specified on the order will reduce the stock on hand. When there is not enough inventory to fulfill the order, the order will be rejected with an "out of stock" error code.
+*   For products that have min and max quantities specified in their settings, the API will honor these, and will reject orders appropriately.
+*   For products where product options are required, the API will validate these requirements to ensure that the product options are specified.
 *   Product quantity must be specified.
 
-##### <span class="jumptarget"> Calculation of Totals </span>
+#### <span class="jumptarget"> Calculation of Totals </span>
 
 *   When not specified, order subtotal and total are automatically calculated.
-*   You can override order subtotal and/or total. If you choose to override one, we strongly recommend that override both as the system will not be able to accurately calculate the other.
+*   You can override order subtotal and/or total. If you choose to override one, we strongly recommend that override both, because the system will not be able to accurately calculate the other.
 
-##### <span class="jumptarget"> Order Properties </span>
+#### <span class="jumptarget"> Order Properties </span>
 
 *   Billing address is mandatory.
-*   Shipping address is not mandatory and can optionally be specified as composite records.
-    *   When the shipping address is not specified, the system will fall back to using the billing address as the shipping address
-    *   Multiple shipments are not supported so it will assume the first address in the collection
-*   In the shipping and billing address, their is no requirement to specify ‘country’ when ‘country_ISO2’ is specified.
-    *   The value specified for ‘country_ISO2’ will always override any value specified for ‘country’
-*   Coupon redemption is not supported at this time.
-*   Set customer_id to 0 to specify a guest checkout.
-*   order_source cannot be specified and it will be set to ‘external’.
-    *   You can optionally specify a value for external_source to specify which external source the order is coming from - i.e., POS system X, accounting system Y, etc
+*   Shipping address is not mandatory, and can optionally be specified as composite records.
+    *   When the shipping address is not specified, the system will fall back to using the billing address as the shipping address.
+    *   Multiple shipments are not supported, so the API will assume the first address in the collection.
+*   In the shipping and billing addresses, there is no requirement to specify `country` when `country_ISO2` is specified.
+    *   The value specified for `country_ISO2` will always override any value specified for `country`.
+*   Coupon redemption is not currently supported.
+*   To specify a guest checkout, set `customer_id` to `0`.
+*   `order_source` cannot be specified, and will be set to `external`.
+    *   You can optionally specify a value for `external_source` to specify which external source the order is coming from - e.g., POS system X, accounting system Y, etc.
 
-##### <span class="jumptarget"> Changing the Order Status </span>
+#### <span class="jumptarget"> Changing the Order Status </span>
 
-*   `status_id` can be specified resulting in the the corresponding ‘status’ to automatically be set. When not specified, status_id will be automatically set to 1 resulting in ‘status’ to be set to ‘Pending’.
+*   You can specify `status_id`, which will automatically set the corresponding `status`. When `status_id` is not specified, it will be automatically set to `1`, which will set `status` to `Pending`.
 
-*   `POST` or `PUT` Orders on stores with Avalara Premium causes tax documents to be submitted. If a store has subscribed to Avalara Premium, Bigcommerce automatically submits tax documents to Avalara when the order achieves a paid status. The following statuses are of the paid type:
+*   `POST` or `PUT` orders on stores with Avalara Premium cause tax documents to be submitted. If a store has subscribed to Avalara Premium, BigCommerce automatically submits tax documents to Avalara when the order achieves a paid status. The following statuses are of the paid type:
     *   Shipped
     *   Partially Shipped
     *   Awaiting Pickup
     *   Awaiting Shipment
     *   Completed
     *   Awaiting Fulfillment
-*   BigCommerce considers all statuses other than the above to be of the unpaid type, except `Refunded`, which is considered neither paid or unpaid. Orders that are created using the `POST` method, and include a status of the paid type, cause the submission of tax documents to Avalara.
+*   BigCommerce considers all statuses other than those above to be of the unpaid type, except `Refunded`, which is considered neither paid or unpaid. Orders that are created using the `POST` method, and that include a status of the paid type, cause the submission of tax documents to Avalara.
 
-```curl
+
+#### <span class="jumptarget"> Request </span>
+
+Example request object:
+
+```json
 {
   "customer_id": 0,
   "status_id": 11,
@@ -420,6 +425,11 @@ You can create overrides for calculated values such as product prices, subtotal 
   "external_source": "POS"
 }
 ```
+
+
+#### <span class="jumptarget"> Response </span>
+
+Example JSON returned in the response:
 
 ```json
 {
@@ -554,7 +564,7 @@ All "Notes," "KNOWN ISSUES," and "PRO TIPs" formatted as `>blockquote` in this `
 
 #### <span class="jumptarget"> Changing the Order Status </span>
 
-The `status` property cannot be edited directly as it is generated based on the `status_id`.
+The `status` property cannot be edited directly, because it is generated based on the `status_id`.
 
 Use the `status_id` property to set the order to a specific state. The list of available statuses is provided by the [Order Statuses](/api/v2#order_statuses) resource. If the store has subscribed to Avalara Premium, tax documents are submitted when the `status_id` property changes. The following table details the behavior for `PUT` operations. See also the list of [Paid Statuses](#paid-status).
 
@@ -581,7 +591,7 @@ Edits to the following properties will trigger a recalculation of the subtotal a
 *   billing_address
 *   shipping_addresses
 
->NOTE: The Orders resource currently does not support coupon redemptions and discounts apart from manual discount. You should only modify the above fields if you have created the order via the POST operation or you intend to override the subtotals and totals manually.
+>NOTE: The Orders resource currently does not support coupon redemptions or discounts, apart from manual discount. You should modify the above fields only if you have created the order via the POST operation, or if you intend to manually override the subtotals and totals.
 
 ### <span class="jumptarget"> Delete an Order </span>
 
@@ -594,7 +604,7 @@ Deletes an order.
 
 #### <span class="jumptarget"> Notes </span>
 
->NOTE: Attempts to `DELETE` an order on a store with automatic tax enabled will fail and return `405 Method not allowed`.
+>NOTE: Attempts to `DELETE` an order on a store with automatic tax enabled will fail, returning `405 Method not allowed`.
 
 ### <span class="jumptarget"> Delete All Orders </span>
 

--- a/source/includes/_api_CRUD_orders.md
+++ b/source/includes/_api_CRUD_orders.md
@@ -43,11 +43,10 @@ Parameters can be added to the URL query string to paginate the collection. The 
 | limit | int | /api/v2/orders?limit={count} |
 | sort | string | /api/v2/orders?sort=date_created:desc |
 
-<aside class="warning">
-<span class="aside-warning-hd">Migration Note</span><br><br>
-All "curl" code examples are presumably json. Restore the missing "...JSON example:..." kickers, conforming to: https://developer.bigcommerce.com/api/stores/v2/orders.
-</aside>
 
+#### <span class="jumptarget"> Response </span>
+
+Example JSON returned in the response:
 
 ```json
 [
@@ -132,6 +131,7 @@ All "curl" code examples are presumably json. Restore the missing "...JSON examp
   }
 ]
 ```
+
 ### <span class="jumptarget"> Get an Order </span>
 
 Gets an order.
@@ -140,6 +140,10 @@ Gets an order.
 >`GET /stores/{store_hash}/v2/orders/{id}`
 *   Basic Auth
 >`GET /api/v2/orders/{id}`
+
+#### <span class="jumptarget"> Response </span>
+
+Example JSON returned in the response:
 
 ```json
 {
@@ -232,6 +236,11 @@ Gets a count of the number of orders in the store.
 *   Basic Auth
 >`GET /api/v2/orders/count`
 
+
+#### <span class="jumptarget"> Response </span>
+
+Example JSON returned in the response:
+
 ```json
 {
   "count": 9
@@ -284,15 +293,18 @@ The following properties of the order are required. The request won’t be fulfi
 *   products
 *   billing_address
 
+
 <aside class="warning">
-<span class="aside-warning-hd">Migration Note</span><br><br>
-All "Notes," "KNOWN ISSUES," and "PRO TIPs" formatted as `>blockquote` in this `_api_CRUD_orders.md` file – starting with those directly below – must be reformatted as appropriately-colored `asides`.
+<span class="aside-warning-hd">Tax Notes</span><br><br>
+
+  <ul>
+	<li>If a store has automatic tax enabled, BigCommerce does not compute sales tax on orders created via the API.
+	</li>
+	<li>Abbreviated state names in shipping and billing addresses will prevent tax documents from being submitted to Avalara. To ensure successful Avalara tax-document submission, spell state names out in full. For example, supplying <code>CA</code> as a state name leads to no tax-document submission. Supplying <code>California</code> as a state name leads to a successful submission.
+	</li>
+  </ul>
 </aside>
 
-#### <span class="jumptarget"> Notes </span>
->KNOWN ISSUE: Bigcommerce does not compute sales tax to orders created via the API if the store has automatic tax enabled.
-
->PRO TIP: Abbreviated state names in shipping and billing addresses will prevent tax documents from being submitted to Avalara. Spell state names out in full to ensure successful Avalara tax document submissions. For example, supplying `CA` as a state name results in no tax document submission. Supplying `California` as a state name results in a successful submission.
 
 #### <span class="jumptarget"> Overriding Preset Values </span>
 
@@ -553,14 +565,13 @@ The following properties of the order are read-only. If one or more of these pro
 *   shipping_address_count
 *   coupons
 
+
 <aside class="warning">
-<span class="aside-warning-hd">Migration Note</span><br><br>
-All "Notes," "KNOWN ISSUES," and "PRO TIPs" formatted as `>blockquote` in this `_api_CRUD_orders.md` file – including those directly below – must be reformatted as appropriately-colored `asides`.
+<span class="aside-warning-hd"> Known Issue </span><br><br>
+
+If a store has automatic tax enabled, BigCommerce does not compute sales tax on orders updated via the API.
 </aside>
 
-#### <span class="jumptarget"> Notes </span>
-
->KNOWN ISSUE: Bigcommerce does not compute sales tax to orders updated via the API if the store has automatic tax enabled.
 
 #### <span class="jumptarget"> Changing the Order Status </span>
 
@@ -591,7 +602,13 @@ Edits to the following properties will trigger a recalculation of the subtotal a
 *   billing_address
 *   shipping_addresses
 
->NOTE: The Orders resource currently does not support coupon redemptions or discounts, apart from manual discount. You should modify the above fields only if you have created the order via the POST operation, or if you intend to manually override the subtotals and totals.
+
+<aside class="warning">
+<span class="aside-warning-hd"> Limitation on Coupons/Discounts </span><br><br>
+
+The Orders resource currently does not support coupon redemptions or discounts, apart from manual discount. You should modify the above fields only if you have created the order via the POST operation, or if you intend to manually override the subtotals and totals.
+</aside>
+
 
 ### <span class="jumptarget"> Delete an Order </span>
 
@@ -602,9 +619,13 @@ Deletes an order.
 *   Basic Auth
 >`DELETE /api/v2/orders/{id}`
 
-#### <span class="jumptarget"> Notes </span>
+<aside class="warning">
+<span class="aside-warning-hd"> Deletion Blocked by Automatic Tax  </span><br><br>
 
->NOTE: Attempts to `DELETE` an order on a store with automatic tax enabled will fail, returning `405 Method not allowed`.
+Any attempts to <code>DELETE</code> an order on a store with automatic tax enabled will fail, and will return <code>405 Method not allowed</code>.
+</aside>
+
+
 
 ### <span class="jumptarget"> Delete All Orders </span>
 

--- a/source/includes/_api_CRUD_payments_methods.md
+++ b/source/includes/_api_CRUD_payments_methods.md
@@ -4,7 +4,7 @@
 | **OAuth Scopes** | store_v2_information
 ||store_v2_information_read_only
 
-## <span class="jumptarget"> List Payment Methods </span>
+### <span class="jumptarget"> List Payment Methods </span>
 
 Gets the list of enabled payment methods. (Default sorting is by payment method, alphabetically from A to Z.)
 
@@ -13,11 +13,11 @@ Gets the list of enabled payment methods. (Default sorting is by payment method,
 *   Basic Auth
 >`GET /api/v2/payments/methods`
 
-### <span class="jumptarget"> Filters </span>
+#### <span class="jumptarget"> Filters </span>
 
 There are no filter parameters specific to payment methods.
 
-### <span class="jumptarget"> Pagination </span>
+#### <span class="jumptarget"> Pagination </span>
 
 Parameters can be added to the URL query string to paginate the collection. The maximum limit is 250. If a limit isn’t provided, up to 50 payment_methods are returned by default.
 

--- a/source/includes/_api_CRUD_products_options.md
+++ b/source/includes/_api_CRUD_products_options.md
@@ -4,7 +4,7 @@
 | **OAuth Scopes** | store_v2_products
 ||store_v2_products_read_only
 
-## <span class="jumptarget"> List Product Options </span>
+### <span class="jumptarget"> List Product Options </span>
 
 Gets the options associated with a product.
 
@@ -13,11 +13,11 @@ Gets the options associated with a product.
 *   Basic Auth
 >`GET /api/v2/products/{product_id}/options`
 
-### <span class="jumptarget"> Filters </span>
+#### <span class="jumptarget"> Filters </span>
 
 There are no filter parameters specific to product options. 
 
-### <span class="jumptarget"> Pagination </span>
+#### <span class="jumptarget"> Pagination </span>
 
 Parameters can be added to the URL query string to paginate the collection. The maximum limit is 250. If a limit isn’t provided, up to 50 product_options are returned by default.
 
@@ -45,7 +45,7 @@ Parameters can be added to the URL query string to paginate the collection. The 
 ]
 ```
 
-## <span class="jumptarget"> Get a Product Option </span>
+### <span class="jumptarget"> Get a Product Option </span>
 
 Gets an option associated with a product.
 

--- a/source/includes/_api_CRUD_products_product_options.md
+++ b/source/includes/_api_CRUD_products_product_options.md
@@ -1,0 +1,77 @@
+## Options associated directly with a product.
+
+|||
+|---|---|
+| **Manages** |
+| **OAuth Scopes** | `store_v2_products`
+||`store_v2_products_read_only`
+
+## Operations
+
+*   [List Product Options](#list-product-options)
+*   [Get a Product Option](#get-a-product-option)
+
+## List Product Options
+
+Gets the options associated with a product.
+
+
+*   [OAuth](#list-product-options-oauth)
+>`GET /stores/{store_hash}/v2/products/{product_id}/options`</div>
+*   [Basic Auth](#list-product-options-basic)
+>`GET /api/v2/products/{product_id}/options`</div>
+
+### Pagination
+
+Parameters can be added to the URL query string to paginate the collection. The maximum limit is 250\. If a limit isn’t provided, up to 50 product_options are returned by default.
+
+| Parameter | Type | Example |
+| --- | --- | --- |
+| `page` | int | `/api/v2/products/{product_id}/options?page={number}` |
+| `limit` | int | `/api/v2/products/{product_id}/options?limit={count}` |
+
+### Response
+
+Example JSON returned in the response:
+
+```
+[
+  {
+    "id": 13,
+    "option_id": 8,
+    "display_name": "iPod Capacities",
+    "sort_order": 0,
+    "is_required": true
+  },
+  {
+    "id": 14,
+    "option_id": 9,
+    "display_name": "Accessories",
+    "sort_order": 1,
+    "is_required": false
+  }
+]
+```
+
+## Get a Product Option
+
+Gets an option associated with a product.
+
+*   [OAuth](#get-a-product-option-oauth)
+">`GET /stores/{store_hash}/v2/products/{product_id}/options/{id}`</div>
+*   [Basic Auth](#get-a-product-option-basic)
+>`GET /api/v2/products/{product_id}/options/{id}`</div>
+
+### Response
+
+Example JSON returned in the response:
+
+```
+{
+  "id": 14,
+  "option_id": 9,
+  "display_name": "Accessories",
+  "sort_order": 1,
+  "is_required": false
+}
+```

--- a/source/includes/_api_CRUD_products_product_options.md
+++ b/source/includes/_api_CRUD_products_product_options.md
@@ -1,4 +1,4 @@
-## Options associated directly with a product.
+Options associated directly with a product.
 
 |||
 |---|---|
@@ -11,17 +11,17 @@
 *   [List Product Options](#list-product-options)
 *   [Get a Product Option](#get-a-product-option)
 
-## List Product Options
+### List Product Options
 
 Gets the options associated with a product.
 
 
 *   [OAuth](#list-product-options-oauth)
->`GET /stores/{store_hash}/v2/products/{product_id}/options`</div>
+>`GET /stores/{store_hash}/v2/products/{product_id}/options`
 *   [Basic Auth](#list-product-options-basic)
->`GET /api/v2/products/{product_id}/options`</div>
+>`GET /api/v2/products/{product_id}/options`
 
-### Pagination
+#### Pagination
 
 Parameters can be added to the URL query string to paginate the collection. The maximum limit is 250\. If a limit isn’t provided, up to 50 product_options are returned by default.
 
@@ -30,11 +30,11 @@ Parameters can be added to the URL query string to paginate the collection. The 
 | `page` | int | `/api/v2/products/{product_id}/options?page={number}` |
 | `limit` | int | `/api/v2/products/{product_id}/options?limit={count}` |
 
-### Response
+#### Response
 
 Example JSON returned in the response:
 
-```
+```json
 [
   {
     "id": 13,
@@ -53,20 +53,20 @@ Example JSON returned in the response:
 ]
 ```
 
-## Get a Product Option
+### Get a Product Option
 
 Gets an option associated with a product.
 
 *   [OAuth](#get-a-product-option-oauth)
-">`GET /stores/{store_hash}/v2/products/{product_id}/options/{id}`</div>
+">`GET /stores/{store_hash}/v2/products/{product_id}/options/{id}`
 *   [Basic Auth](#get-a-product-option-basic)
->`GET /api/v2/products/{product_id}/options/{id}`</div>
+>`GET /api/v2/products/{product_id}/options/{id}`
 
-### Response
+#### Response
 
 Example JSON returned in the response:
 
-```
+```json
 {
   "id": 14,
   "option_id": 9,

--- a/source/includes/_api_CRUD_webhooks.md
+++ b/source/includes/_api_CRUD_webhooks.md
@@ -3,7 +3,7 @@
 | **Manages** |
 | **OAuth Scopes** | `default`
 
-## <span class="jumptarget"> List Hooks </span>
+### <span class="jumptarget"> List Hooks </span>
 
 Index of registered webhooks.
 
@@ -41,7 +41,7 @@ Index of registered webhooks.
 ]
 ```
 
-## <span class="jumptarget"> Get a Hook </span>
+### <span class="jumptarget"> Get a Hook </span>
 
 Gets a registered webhook.
 
@@ -64,25 +64,25 @@ Gets a registered webhook.
 }
 ```
 
-## <span class="jumptarget"> Create a Hook </span>
+### <span class="jumptarget"> Create a Hook </span>
 
 Register a new webhook.
 
 *   OAuth
 >`POST /stores/{store_hash}/v2/hooks`
 
-### <span class="jumptarget"> Requirements </span>
+#### <span class="jumptarget"> Requirements </span>
 
 The following properties of the webhooks are required. The request won’t be fulfilled unless these properties are valid.
 
 *   scope
 *   destination
 
-### <span class="jumptarget"> Notes </span>
+#### <span class="jumptarget"> Notes </span>
 
 Scopes can be specified using wildcard syntax, or the full path to an event.
 
-```curl
+```json
 {
   "scope": "store/order/*",
   "headers": {
@@ -93,19 +93,28 @@ Scopes can be specified using wildcard syntax, or the full path to an event.
 }
 ```
 
-## <span class="jumptarget"> Update a Hook </span>
+### <span class="jumptarget"> Update a Hook </span>
 
 Edit the details of a registered webhook.
 
 *   OAuth
 >`PUT /stores/{store_hash}/v2/hooks/{id}`
+    
+#### <span class="jumptarget"> Request </span>
 
-```curl
+Example request object:
+
+```json
 {
   "destination": "https://app.example.com/orders_changed",
   "is_active": true
 }
 ```
+
+#### <span class="jumptarget"> Response </span>
+
+Example JSON returned in the response:
+
 
 ```json
 {
@@ -123,7 +132,7 @@ Edit the details of a registered webhook.
 }
 ```
 
-## <span class="jumptarget"> Delete a Hook </span>
+### <span class="jumptarget"> Delete a Hook </span>
 
 Deletes a single webhook.
 

--- a/source/includes/_api_faqs.md
+++ b/source/includes/_api_faqs.md
@@ -1,3 +1,6 @@
+# <span class="jumptarget"> FAQ </span>
+
+
 ## <span class="jumptarget"> What kind of apps can I submit?</span>
 
 You can build any kind of app to test the capabilities of the platform. For inclusion in the App Store, we’re looking for apps that that make online retail better and help our merchants to sell more.

--- a/source/includes/_api_legacy_basic_auth.md
+++ b/source/includes/_api_legacy_basic_auth.md
@@ -1,8 +1,9 @@
-Private apps require the manual creation of an API token for each store, and are most useful for custom integrations for a single Bigcommerce store. They use HTTP Basic Authentication, and communicate directly with the store's API endpoints.
+Basic-Auth (or "Private") apps require the manual creation of an API token for each store. They are most useful for custom integrations for a single BigCommerce store. They use HTTP Basic Authentication, and communicate directly with the store's API endpoints.
 
 <aside class="warning">
 <span class="aside-warning-hd">Limited Support for Basic Auth </span><br><br>
-Not all features of the Stores API are available to apps using Basic Authentication. For example, the Webhooks resource requires OAuth.
+BigCommerce is gradually deprecating Basic Authentication. Apps must use <a href="#building-oauth-apps">OAuth</a> to access our v3 API.   
+Even within the v2 API, apps relying on Basic Authentication cannot access some features: For example, the Webhooks resource requires OAuth.
 </aside>
 
 

--- a/source/includes/_api_objects_brand.md
+++ b/source/includes/_api_objects_brand.md
@@ -1,8 +1,12 @@
-# <span class="jumptarget"> Brands </span>
+# <span class="jumptarget"> Products Reference </span>
+
+Products APIs include Brands, Buk Pricing Rules, Categories, Configurable Fields, Custom Fields, Google Product Search Mappings, Options, Option Sets, Option Set Options, Option Values, Products, Product Images, Product[-specific] Options, Product Reviews, Product Rules, Product Videos, and SKUs.
+
+## <span class="jumptarget"> Brands </span>
 
 Brand facets for identifying and categorizing products according to their manufacturer or company metonym.
 
-## <span class="jumptarget"> Brand Object – Properties </span>
+### <span class="jumptarget"> Brand Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/source/includes/_api_objects_order.md
+++ b/source/includes/_api_objects_order.md
@@ -56,7 +56,7 @@ A record of the purchase agreement between a shopper and a merchant.
 | default_currency_id | int | A read-only value. Do not pass in a POST or PUT. |
 | default_currency_code | string | The currency code of the default currency for this type of transaction. A read-only value. Do not pass in a POST or PUT. |
 | staff_notes | text | Any additional notes for staff. |
-| customer_message | text | Message for the customer. |
+| customer_message | text | Message that the customer entered into the `Order Comments` box during checkout. |
 | discount_amount | decimal | Amount of discount for this transaction. |
 | coupon_discount | decimal | A read-only value. Do not pass in a POST or PUT. |
 | shipping_address_count | int | The number of shipping addresses associated with this transaction. A read-only value. Do not pass in a POST or PUT. |

--- a/source/includes/_api_objects_payment_method.md
+++ b/source/includes/_api_objects_payment_method.md
@@ -1,8 +1,12 @@
-# <span class="jumptarget"> Payment Methods </span>
+# <span class="jumptarget"> Payment Methods Reference </span>
+
+This section covers the Payment Method object and Payment Methonds endpoints.
+
+## <span class="jumptarget"> Payment Methods </span>
 
 Enabled payment types or methods in a store.
 
-## <span class="jumptarget"> Payment Method Object – Properties </span>
+### <span class="jumptarget"> Payment Method Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/source/includes/_api_objects_product.md
+++ b/source/includes/_api_objects_product.md
@@ -1,8 +1,8 @@
-# <span class="jumptarget"> Products </span>
+## <span class="jumptarget"> Products </span>
 
 A saleable item in the catalog.
 
-## <span class="jumptarget"> Product Object – Properties </span>
+### <span class="jumptarget"> Product Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- | --- |

--- a/source/includes/_api_objects_product_product_option.md
+++ b/source/includes/_api_objects_product_product_option.md
@@ -1,0 +1,14 @@
+|||
+|---|---|
+| Managed by | [Product Options Resource](/api/stores/v2/products/options)
+
+
+## Properties
+
+| Title | Name | Type | Description |
+| --- | --- | --- | --- |
+| `id` | `int` |
+| `option_id` | `int` |
+| `display_name` | `string` |
+| `sort_order` | `int` |
+| `is_required` | `boolean` |

--- a/source/includes/_api_objects_product_product_option.md
+++ b/source/includes/_api_objects_product_product_option.md
@@ -1,9 +1,11 @@
+## Product Options
+
 |||
 |---|---|
 | Managed by | [Product Options Resource](/api/stores/v2/products/options)
 
 
-## Properties
+### <span class="jumptarget"> Product Options Object – Properties </span>
 
 | Title | Name | Type | Description |
 | --- | --- | --- | --- |

--- a/source/includes/_api_objects_webhook.md
+++ b/source/includes/_api_objects_webhook.md
@@ -1,8 +1,10 @@
-# <span class="jumptarget"> Webhook object </span>
+# <span class="jumptarget"> Webhooks Reference </span>
+
+## <span class="jumptarget"> Webhook Object </span>
 
 Register and manage webhooks that connect events from a store to external URLs.
 
-## <span class="jumptarget"> Properties </span>
+### <span class="jumptarget"> Webhook Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |

--- a/source/themes/blueprint/index.html.md
+++ b/source/themes/blueprint/index.html.md
@@ -2,15 +2,6 @@
 title: BigCommerce Blueprint Themes
 layout: "twocolumn"
 
-toc_footers:
-  - <a href="/">Home</a>
-  - <a href='/api/v2/'>API</a>
-  - <a href='/themes/'>Themes</a>
-  - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp;  Stencil Themes</a>
-  - <a href='#'>Sign Up for a Developer Key</a>
-  - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
-
 includes:
   - themes_features
   - themes_anatomy
@@ -19,6 +10,15 @@ includes:
   - themes_product_filtering_toolkit
   - themes_syntax
   - themes_theme_update_process
+
+toc_footers:
+  - <a href="/">Home</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
 
 search: true
 ---

--- a/source/themes/blueprint/index.html.md
+++ b/source/themes/blueprint/index.html.md
@@ -4,6 +4,7 @@ layout: "twocolumn"
 
 includes:
   - themes_features
+  - api_browsers.md
   - themes_anatomy
   - themes_blueprint
   - themes_style_editor

--- a/source/themes/index.html.md
+++ b/source/themes/index.html.md
@@ -4,13 +4,12 @@ layout: "twocolumn"
 
 toc_footers:
   - <a href="/">Home</a>
-  - <a href='/api/'>API</a>
-  - <a href='/themes/'>Themes</a>
-  - <a href='/themes/blueprint/'> &nbsp; Blueprint Themes</a>
-  - <a href='https://stencil.bigcommerce.com/docs'> &nbsp; Stencil Themes</a>
-  - <a href='#'>Sign Up for a Developer Key</a>
-  - <a href='http://goo.gl/forms/380FmYFlaJ05CL3q2'>Sign Up for the Developer Newsletter</a>
-  - <a href='http://github.com/tripit/slate'>Documentation by Slate</a>
+  - <a href="/api/">API - Basics</a>
+  - <a href="/themes/">Themes</a>
+  - <a href="https://stencil.bigcommerce.com/docs/"> &nbsp;  Stencil Themes</a>
+  - <a href="/themes/blueprint/"> &nbsp; Blueprint Themes</a>
+  - <a href="http://goo.gl/forms/380FmYFlaJ05CL3q2" target="_blank">Sign Up for the Developer Newsletter</a>
+  - <a href="http://github.com/tripit/slate" target="_blank">Site Built with Slate</a>
 
 search: true
 ---


### PR DESCRIPTION
Moved "Building OAuth/Basic-Auth Apps" to API > root. Resumed reorganizing API > v2 > TOC and TOC footer. The `index.html.md` file now completely conforms to legacy Dev Portal structure. However, within the `include` files, _many_ heads still need to be demoted one level, to get the left TOC pane to render the proper structure.