### PR TITLE
Last api index fixes + Themes TOC top fixes

### DIFF
--- a/source/api/v2/index.html.md
+++ b/source/api/v2/index.html.md
@@ -37,8 +37,8 @@ includes:
   - api_CRUD_orders_shipping_addresses
   - api_objects_order_status
   - api_CRUD_orders_statuses
-  - api_objects_order_tax.md
-  - api_CRUD_orders_taxes.md
+  - api_objects_order_tax
+  - api_CRUD_orders_taxes
   - api_objects_order_shipment
   - api_CRUD_orders_shipments
   - api_objects_payment_method
@@ -56,7 +56,7 @@ includes:
   - api_objects_product_googleproductsearch
   - api_CRUD_products_googleproductsearch
   - api_objects_product_option
-  - api_CRUD_options.md
+  - api_CRUD_options
   - api_objects_option_set
   - api_CRUD_option_sets
   - api_objects_option_set_option
@@ -86,7 +86,7 @@ includes:
   - api_CRUD_tax_classes
   - api_objects_webhook
   - api_CRUD_webhooks
-  - api_browsers.md
+  - api_browsers
   - api_status_codes
   - api_data_types
   - api_faqs

--- a/source/includes/_themes_understanding.md
+++ b/source/includes/_themes_understanding.md
@@ -1,0 +1,19 @@
+# Understanding Themes
+
+<!-- For information about our new themes framework, **Stencil**, please explore our [Stencil documentation](https://stencil.bigcommerce.com/docs/).
+
+For information about our legacy  Blueprint themes framework, please follow the navigation links within this portal. -->
+
+Themes allow you to customize the look and feel of Bigcommerce stores. The compelling store designs in the [BigCommerce&#160;Showcase](http://www.bigcommerce.com/showcase/) demonstrate the kinds of things that can be done.
+
+To ensure that your themes make the most of BigCommerce’s extensive out-of-the-box features and capabilities, please be aware of all the [supported features](https://www.bigcommerce.com/features/all/) that store owners manage and maintain through the Bigcommerce control panel.
+
+You can ask further questions, and seek advice, in the [Developer Forum](https://forum.bigcommerce.com/s/group/0F913000000HLjECAW). For professional assistance in customizing a theme, consider hiring a [BigCommerce Expert](http://www.bigcommerce.com/experts/).
+
+<span class="fake-h3"> [Stencil](https://stencil.bigcommerce.com) </span>
+
+  Handlebars.js-based theming engine, designed to support  local development, conditional logic, flexible choice of libraries, and responsive layouts.
+
+<span class="fake-h3"> [Blueprint](/themes/blueprint) </span>
+
+  Legacy theming framework. Uses a proprietary templating language; offers merchants direct HTML customization.

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -930,12 +930,21 @@ img {
 
 .fake-h2, .fake-h2 p, .fake-h2 a  {
      @extend %header-font;
+     // Added 9/29/16:
+     text-shadow: $main-embossed-text-shadow;
+     font-weight: 500;
+     color: #4b71fc;
+     margin-bottom: 15px;
      font-size: 26px !important;
    }
 
 .fake-h3, .fake-h3 p, .fake-h3 a {
     @extend %header-font;
-    font-size: 22px !important;
+     // Added 9/29/16:
+     text-shadow: $main-embossed-text-shadow;
+     font-weight: 500;
+     color: #4b71fc;
+     font-size: 22px !important;
   }
 
 

--- a/source/themes/index.html.md
+++ b/source/themes/index.html.md
@@ -2,6 +2,10 @@
 title: BigCommerce Themes
 layout: "twocolumn"
 
+includes:
+- themes_understanding
+- themes_features
+
 toc_footers:
   - <a href="/">Home</a>
   - <a href="/api/">API - Basics</a>
@@ -13,23 +17,3 @@ toc_footers:
 
 search: true
 ---
-
-# Understanding Themes
-
-<!-- For information about our new themes framework, **Stencil**, please explore our [Stencil documentation](https://stencil.bigcommerce.com/docs/).
-
-For information about our legacy  Blueprint themes framework, please follow the navigation links within this portal. -->
-
-Themes allow you to customize the look and feel of Bigcommerce stores. The compelling store designs in the [BigCommerce Showcase](http://www.bigcommerce.com/showcase/) demonstrate the kinds of things that can be done.
-
-To ensure that your themes make the most of BigCommerce’s extensive out-of-the-box features and capabilities, please be aware of all the [supported features](https://www.bigcommerce.com/features/all/) that store owners manage and maintain through the Bigcommerce control panel.
-
-You can ask further questions, and seek advice, in the [Developer Forum](https://forum.bigcommerce.com/s/group/0F913000000HLjECAW). For professional assistance in customizing a theme, consider hiring a [BigCommerce Expert](http://www.bigcommerce.com/experts/).
-
-### [Stencil](//stencil.bigcommerce.com)
-
-  Handlebars.js-based theming engine, designed to support  local development, conditional logic, flexible choice of libraries, and responsive layouts.
-
-### [Blueprint](/themes/blueprint)
-
-  Legacy theming framework. Uses a proprietary templating language; offers merchants direct HTML customization.


### PR DESCRIPTION
Removed `*.md` from `/api/v2/` includes references. Separated out
Themes > landing page/screen as new `_themes_understanding.md` file.
Adjusted CSS > `fake-h2` & `fake-h3` styles (to look like h2 & h3) &
applied those styles. SLOPPY CSS, should REFACTOR later.