### PR TITLE
Fuzzier Search test

### DIFF
--- a/source/javascripts/lib/_lunr.js
+++ b/source/javascripts/lib/_lunr.js
@@ -1090,7 +1090,9 @@
             // to the token.
             if (key !== token) {
               var diff = Math.max(3, key.length - token.length)
-              similarityBoost = 1 / Math.log(diff)
+              /** similarityBoost = 1 / Math.log(diff) */
+              /** Try 11/8/15: Divide boost by 10, to help boolean (implicit AND) keyword combo's show: */
+              similarityBoost = 0.1 / Math.log(diff)
             }
 
             // calculate the query tf-idf score for this token


### PR DESCRIPTION
Try: Cut the “similarityBoost” on exact search keys by 9/10. Lunr’s
site claims this should reveal matches for non-adjacent word pairs used
as search keys.