### PR TITLE
404 page w/more back links

### DIFF
--- a/source/layouts/404.erb
+++ b/source/layouts/404.erb
@@ -75,7 +75,7 @@ under the License.
                             <h1 style="font-size:3.45556rem;"><br>
                             404 – Page Not Found</h1>
                             <p><span class="type-large">Sorry! This was a bad link.</span></p>
-                            <p><span class="type-large">We relaunched these docs on 9/30/16, and many URLs have changed. With our apologies for any inconvenience, please&#160;search by keyword on our new site's search box.</span></p>
+                            <p><span class="type-large">We relaunched these docs on 9/30/16, and many URLs have changed. With our apologies for any inconvenience, please&#160;search by keyword in our new site's search box.</span></p>
                             <p>Jump/back to:<span class="type-large"><br></span>API DOCUMENTATION: &nbsp; &nbsp; &nbsp; &nbsp; <a href="/api">Basics</a> <span class="home-separator"> | </span> <a href="/api/v2">v2</a> <span class="home-separator"> | </span> <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md">v3</a> <br> THEME DOCUMENTATION: <a href="/themes">Basics</a> <span class="home-separator"> | </span> <a href="/themes/blueprint">Blueprint</a> <span class="home-separator"> | </span> <a href="http://stencil.bigcommerce.com/docs">Stencil</a> </p>
                         </div>
                     </div>

--- a/source/layouts/404.erb
+++ b/source/layouts/404.erb
@@ -75,7 +75,8 @@ under the License.
                             <h1 style="font-size:3.45556rem;"><br>
                             404 – Page Not Found</h1>
                             <p><span class="type-large">Sorry! This was a bad link.</span></p>
-                            <p>Back to:<span class="type-large"><br></span>API DOCUMENTATION: &nbsp; &nbsp; &nbsp; &nbsp; <a href="/api">Basics</a> <span class="home-separator"> | </span> <a href="/api/v2">v2</a> <span class="home-separator"> | </span> <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md">v3</a> <br> THEME DOCUMENTATION: <a href="/themes">Basics</a> <span class="home-separator"> | </span> <a href="/themes/blueprint">Blueprint</a> <span class="home-separator"> | </span> <a href="http://stencil.bigcommerce.com/docs">Stencil</a> </p>
+                            <p><span class="type-large">We relaunched these docs on 9/30/16, and many URLs have changed. With our apologies for any inconvenience, please&#160;search by keyword on our new site's search box.</span></p>
+                            <p>Jump/back to:<span class="type-large"><br></span>API DOCUMENTATION: &nbsp; &nbsp; &nbsp; &nbsp; <a href="/api">Basics</a> <span class="home-separator"> | </span> <a href="/api/v2">v2</a> <span class="home-separator"> | </span> <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md">v3</a> <br> THEME DOCUMENTATION: <a href="/themes">Basics</a> <span class="home-separator"> | </span> <a href="/themes/blueprint">Blueprint</a> <span class="home-separator"> | </span> <a href="http://stencil.bigcommerce.com/docs">Stencil</a> </p>
                         </div>
                     </div>
                 </div>

--- a/source/layouts/404.erb
+++ b/source/layouts/404.erb
@@ -75,7 +75,7 @@ under the License.
                             <h1 style="font-size:3.45556rem;"><br>
                             404 – Page Not Found</h1>
                             <p><span class="type-large">Sorry! This was a bad link.</span></p>
-                            <p>Back to:<span class="type-large"><br></span><a href="/api">API DOCUMENTATION</a><span class="home-separator"> | </span><a href="/themes">THEME DOCUMENTATION</a> </p>
+                            <p>Back to:<span class="type-large"><br></span>API DOCUMENTATION: &nbsp; &nbsp; &nbsp; &nbsp; <a href="/api">Basics</a> <span class="home-separator"> | </span> <a href="/api/v2">v2</a> <span class="home-separator"> | </span> <a href="https://github.com/bigcommerce/api/blob/master/docs/v3-catalog.md">v3</a> <br> THEME DOCUMENTATION: <a href="/themes">Basics</a> <span class="home-separator"> | </span> <a href="/themes/blueprint">Blueprint</a> <span class="home-separator"> | </span> <a href="http://stencil.bigcommerce.com/docs">Stencil</a> </p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Alignment between API vs. Themes rows is hacked – feel free to refactor
– but here’s the result I’m proposing.