### PR TITLE
Order > Shipment (API-663) fixes

### DIFF
--- a/source/includes/_api_CRUD_blog_posts.md
+++ b/source/includes/_api_CRUD_blog_posts.md
@@ -173,9 +173,11 @@ The following properties of the blog post are required. The request won’t be f
 
 #### <span class="jumptarget"> Notes </span>
 
-Blog posts default to draft status. Set `is_published` to true to publish posts to the storefront.
+* When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. The example request below includes a `published_date` in RFC 2822 format.
 
-If a custom url is not provided, the post’s URL will be generated based on the value of `title`.
+* Blog posts default to draft status. Set `is_published` to true to publish posts to the storefront.
+
+* If a custom URL is not provided, the post’s URL will be generated based on the value of `title`.
 
 #### <span class="jumptarget"> Request </span>
 
@@ -187,6 +189,7 @@ Example request object:
   "body": "<p>This is a blog post.</p>",
   "author": "Author Name",
   "thumbnail_path": "http://cdn.example.com/sample-post.jpg",
+  "published_date": "Mon, 09 May 2015 16:20:04 +0400",
   "is_published": true,
   "tags": [
     "Blog",
@@ -212,6 +215,10 @@ The following properties of the blog post are read-only. If one or more of these
 *   id
 *   preview_url
 
+#### <span class="jumptarget"> Notes </span>
+
+* When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. The example request below includes a `published_date` in RFC 2822 format.
+
 #### <span class="jumptarget"> Request </span>
 
 Example request object:
@@ -220,6 +227,7 @@ Example request object:
 {
   "title": "New: A Sample Blog Post",
   "url": "/blog/sample-post"
+  "published_date": "Wed, 01 Jan 2017 15:33:33 +0400",
 }
 ```
 

--- a/source/includes/_api_CRUD_blog_posts.md
+++ b/source/includes/_api_CRUD_blog_posts.md
@@ -173,9 +173,9 @@ The following properties of the blog post are required. The request won’t be f
 
 #### <span class="jumptarget"> Notes </span>
 
-* When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. The example request below includes a `published_date` in RFC 2822 format.
+* When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. The&#160;example request below includes a `published_date` in RFC 2822 format.
 
-* Blog posts default to draft status. Set `is_published` to true to publish posts to the storefront.
+* Blog posts default to draft status. To publish blog posts to the storefront, set their `is_published` property to `true`.
 
 * If a custom URL is not provided, the post’s URL will be generated based on the value of `title`.
 
@@ -217,7 +217,7 @@ The following properties of the blog post are read-only. If one or more of these
 
 #### <span class="jumptarget"> Notes </span>
 
-* When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. The example request below includes a `published_date` in RFC 2822 format.
+* When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. The&#160;example request below includes a `published_date` in RFC 2822 format.
 
 #### <span class="jumptarget"> Request </span>
 
@@ -226,8 +226,8 @@ Example request object:
 ```json
 {
   "title": "New: A Sample Blog Post",
-  "url": "/blog/sample-post"
-  "published_date": "Wed, 01 Jan 2017 15:33:33 +0400",
+  "url": "/blog/sample-post",
+  "published_date": "Wed, 01 Jan 2017 15:33:33 +0400"
 }
 ```
 

--- a/source/includes/_api_CRUD_orders_shipments.md
+++ b/source/includes/_api_CRUD_orders_shipments.md
@@ -209,6 +209,14 @@ The following properties of the shipment are required. The request won’t be fu
 
 *   order_address_id
 *   items
+*   shipping_provider
+
+#### <span class="jumptarget"> Notes </span>
+
+* For the `shipping_provider` property, acceptable values are an empty string (`""`), or one of these valid BigCommerce shipping-provider values: `auspost`, `canadapost`, `endicia`, `usps`, `fedex`, `royalmail`, `ups`, `upsready`, `upsonline`, or `shipperhq`.
+* If your POST request does not include `shipping_provider` – at least as an empty string, as shown in the example request below – this property's value will default to `custom`, and no tracking link will be generated in the email. 
+* `tracking_carrier` is optional, but if you include it, its value must refer/map to the same carrier service as the `shipping_provider` value. Acceptable values for `tracking_carrier` are an empty string (`""`), or one of the valid tracking-carrier values viewable [here](https://docs.google.com/spreadsheets/d/1w9c_aECSCGyf-oOrvGeUniDl-ARGKemfZl0qSsav8D4/pubhtml?gid=0&single=true) and downloadable as a .CSV file [here](https://docs.google.com/spreadsheets/d/1mTueEynfcEmwsU2y2Jd2MX-8GKwNZrmlRMBcIElg9aY/pub?gid=0&single=true&output=csv).
+
 
 #### <span class="jumptarget"> Request </span>
 
@@ -219,6 +227,7 @@ Example request object:
   "tracking_number": "EJ958083578US",
   "comments": "Ready to go...",
   "order_address_id": 1,
+  "shipping_provider": "",
   "items": [
     {
       "order_product_id": 15,
@@ -281,14 +290,6 @@ Example JSON returned in the response:
   ]
 }
 ```
-
-#### <span class="jumptarget"> Notes </span>
-
-The following properties of the shipments are optional, but if you provide both values, they must refer/map to the same carrier service: 
-
-* `shipping_provider`: Acceptable values are an empty string (`""`), or one of these valid BigCommerce shipping- provider values: `auspost`, `canadapost`, `endicia`, `usps`, `fedex`, `royalmail`, `ups`, `upsready`, `upsonline`, or `shipperhq`.
-* `tracking_carrier`: Acceptable values are an empty string (`""`), or one of the valid tracking-carrier values viewable [here](https://docs.google.com/spreadsheets/d/1w9c_aECSCGyf-oOrvGeUniDl-ARGKemfZl0qSsav8D4/pubhtml?gid=0&single=true) and downloadable as a .CSV file [here](https://docs.google.com/spreadsheets/d/1mTueEynfcEmwsU2y2Jd2MX-8GKwNZrmlRMBcIElg9aY/pub?gid=0&single=true&output=csv).
-
 
 ### <span class="jumptarget"> Update a Shipment </span>
 

--- a/source/includes/_api_CRUD_shipping_zones_methods.md
+++ b/source/includes/_api_CRUD_shipping_zones_methods.md
@@ -1,6 +1,6 @@
 ## <span class="jumptarget"> List Shipping Methods </span>
 
-Gets all configured shipping methods, by zone ID. (Default sorting is by shipping-method ID, from lowest to highest.)
+Gets all configured shipping methods, by `zone_id`. (Default sorting is by shipping-method `id`, from lowest to highest.)
 
 *   OAuth
 >`GET {store_hash}/api/v2/shipping/zones/{zone_id}/methods`
@@ -60,17 +60,17 @@ Example JSON returned in the response:
 
 ## <span class="jumptarget"> Get a Shipping Method </span>
 
-Gets a shipping method, specified by zone ID and method ID.
+Gets a shipping method, specified by `zone_id` and method `id`.
 
 *   OAuth
->`GET {store_hash}/api/v2/shipping/zones/{zone_id}/methods/{method_id}`
+>`GET {store_hash}/api/v2/shipping/zones/{zone_id}/methods/{id}`
 
 ### <span class="jumptarget"> Requirements </span>
 
 The following properties of the shipping zone are required. The request won't be fulfilled unless these properties are valid.
 
 * zone_id
-* method_id
+* [method] id
 
 ### <span class="jumptarget"> Response </span>
 
@@ -153,7 +153,7 @@ Updates an existing shipping method.
 The following properties of the shipping zone are required. The request won't be fulfilled unless these properties are valid.
 
 * zone_id
-* method_id
+* [method] id
 
 ### <span class="jumptarget"> Request </span>
 
@@ -201,4 +201,4 @@ Deletes a specified shipping method. (If successful, this will typically return 
 The following properties of the shipping zone are required. The request won't be fulfilled unless these properties are valid.
 
 * zone_id
-* method_id
+* [method] id

--- a/source/includes/_api_objects_blog_post.md
+++ b/source/includes/_api_objects_blog_post.md
@@ -18,8 +18,8 @@ A content entry in the store’s blog.
 | tags | array of strings |  |
 | summary | string |  |
 | is_published | boolean |  |
-| published_date | object | Members are `date` (date string), `timezone_type` (integer), and `timezone` (string representing an hours:minutes offset, in the format `"+hh:mm"` or `"-hh:mm"`). |
-| published_date_iso8601 | date string |  |
+| published_date | date string, or object | In `PUT` or `POST` requests, supply the blog post's `published_date` as a flat date string, in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. <br> <br> In GET requests, the `published_date` is an object whose members are: <br> `date` (date string); <br> `timezone_type` (integer); <br> and `timezone` (string representing an hours:minutes offset, in the format `"+hh:mm"` or `"-hh:mm"`). |
+| published_date_iso8601 | date string | Published date in <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. |
 | meta_description | string |  |
 | meta_keywords | string |  |
 | author | string |  |

--- a/source/includes/_api_objects_blog_post.md
+++ b/source/includes/_api_objects_blog_post.md
@@ -18,7 +18,7 @@ A content entry in the store’s blog.
 | tags | array of strings |  |
 | summary | string |  |
 | is_published | boolean |  |
-| published_date | date string, or object | In `PUT` or `POST` requests, supply the blog post's `published_date` as a flat date string, in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. <br> <br> In GET requests, the `published_date` is an object whose members are: <br> `date` (date string); <br> `timezone_type` (integer); <br> and `timezone` (string representing an hours:minutes offset, in the format `"+hh:mm"` or `"-hh:mm"`). |
+| published_date | date string, or object | When including the blog post's `published_date` in `PUT` or `POST` requests, supply it as a flat date string in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> or <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. <br> <br> In GET requests, the `published_date` is returned as an object, whose members are: `date` (date string); `timezone_type` (integer); and `timezone` (string representing an hours:minutes offset, in the format `"+hh:mm"` or `"-hh:mm"`). |
 | published_date_iso8601 | date string | Published date in <a href="https://en.wikipedia.org/wiki/ISO_8601" target="_blank">ISO 8601</a> format. |
 | meta_description | string |  |
 | meta_keywords | string |  |

--- a/source/includes/_api_objects_order_shipment.md
+++ b/source/includes/_api_objects_order_shipment.md
@@ -12,10 +12,10 @@ Tracks a package consignment from an order that is shipped from the seller to th
 | order_address_id | int | ID of the associated order address. |
 | date_created | date | Creation date for the shipment. |
 | tracking_number | string | Tracking number of the shipment. |
-| shipping_method | string | Extra detail to describe the shipment, with values like: `Standard`, `My Custom Shipping Method Name`, etc. Can also be used for live quotes from some shipping providers. |
-| shipping_provider | string | Enum of the BigCommerce shipping-carrier integration/module. (<strong>Note:</strong> This property should be included in a POST request to create a shipment object. If it is omitted from the request, the property's value will default to `custom`, and no tracking link will be generated in the email. To avoid this behavior, you can pass the element as an empty string.) |
+| shipping_method | string | Extra detail to describe the shipment, with values like: `Standard`, <br> `My Custom Shipping Method Name`, etc. Can also be used for live quotes from some shipping providers. |
+| shipping_provider | string | Enum of the BigCommerce shipping-carrier integration/module. <br>  (<strong>Note:</strong> This property should be included in a POST request to create a shipment object. If it is omitted from the request, the property's value will default to `custom`, and no tracking link will be generated in the email. To avoid this behavior, you can pass the property as an empty string.) |
 | tracking_carrier | string | Enum of the delivery service fulfilling the shipment. |
 | comments | text | Comments the shipper wishes to add. |
 | billing_address | object | Billing address for this order's customer. |
 | shipping_address | object | Shipping address for this order's customer. |
-| items | object_array | The items in the shipment. This object's members follow the conventions of the [order products](/api/v2/#order-product-object-properties) object. A sample `items` value might be: `[{"order_product_id":15,"quantity":2}]` |
+| items | object_array | The items in the shipment. This object has the following members, all integer: `order_product_id` (required), `quantity` (required), `product_id` (read-only). A sample `items` value might be: `[ {"order_product_id":16,"product_id": 0,"quantity":2} ]` |

--- a/source/includes/_api_objects_order_shipment.md
+++ b/source/includes/_api_objects_order_shipment.md
@@ -1,21 +1,21 @@
 ## <span class="jumptarget"> Shipments </span>
 
-Tracks a package consignment from an order, shipped from the seller to the buyer.
+Tracks a package consignment from an order that is shipped from the seller to the buyer.
 
 ### <span class="jumptarget"> Shipment Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |
-| id | int |
-| order_id | int |
-| customer_id | int |
-| order_address_id | int | ID of the order address with which this shipment is associated |
-| date_created | date |
-| tracking_number | string | Tracking number of the shipment |
-| shipping_method | string |
-| shipping_provider | string | Enum of the BigCommerce shipping-carrier integration/module |
-| tracking_carrier | string | Enum of the delivery service fulfilling the shipment |
-| comments | text | Comments the shipper wishes to add |
-| billing_address | object |
-| shipping_address | object |
-| items | object_array | The items in the shipment. This is an object; see the items table. A sample value might be: [{"order_product_id":15,"quantity":2}]
+| id | int | Shipment ID. |
+| order_id | int | ID of the order associated with this shipment. |
+| customer_id | int | ID of this order's customer. |
+| order_address_id | int | ID of the associated order address. |
+| date_created | date | Creation date for the shipment. |
+| tracking_number | string | Tracking number of the shipment. |
+| shipping_method | string | Extra detail to describe the shipment, with values like: `Standard`, `My Custom Shipping Method Name`, etc. Can also be used for live quotes from some shipping providers. |
+| shipping_provider | string | Enum of the BigCommerce shipping-carrier integration/module. (<strong>Note:</strong> This property should be included in a POST request to create a shipment object. If it is omitted from the request, the property's value will default to `custom`, and no tracking link will be generated in the email. To avoid this behavior, you can pass the element as an empty string.) |
+| tracking_carrier | string | Enum of the delivery service fulfilling the shipment. |
+| comments | text | Comments the shipper wishes to add. |
+| billing_address | object | Billing address for this order's customer. |
+| shipping_address | object | Shipping address for this order's customer. |
+| items | object_array | The items in the shipment. This object's members follow the conventions of the [order products](/api/v2/#order-product-object-properties) object. A sample `items` value might be: `[{"order_product_id":15,"quantity":2}]` |


### PR DESCRIPTION
Added missing descriptions. Clarified that `shipping_provider` is
required in POST requests, to avoid counterintuitive fallback/default
behavior.