### PR TITLE
DEV 20: Added functionality to generate sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'middleman-autoprefixer', '~> 2.7.0'
 gem "middleman-sprockets", "~> 4.0.0.rc"
 gem 'rouge', '~> 1.10.1'
 gem 'redcarpet', '~> 3.3.2'
+
+# Sitemap 
+gem 'builder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       execjs
       json
     backports (3.6.7)
+    builder (3.2.2)
     capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -122,6 +123,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  builder
   middleman (~> 4.0.0)
   middleman-autoprefixer (~> 2.7.0)
   middleman-gh-pages (~> 0.0.3)
@@ -131,4 +133,4 @@ DEPENDENCIES
   rouge (~> 1.10.1)
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/config.rb
+++ b/config.rb
@@ -9,6 +9,9 @@ set :markdown,
     with_toc_data: true,
     no_intra_emphasis: true
 
+# Sitemap
+page "/sitemap.xml", :layout => false
+
 # Assets
 set :css_dir, 'stylesheets'
 set :js_dir, 'javascripts'

--- a/data/site.yml
+++ b/data/site.yml
@@ -1,0 +1,1 @@
+url: https://developer.bigcommerce.com

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,2 +1,0 @@
-#User-agent: *
-#Disallow: /

--- a/source/robots.txt.erb
+++ b/source/robots.txt.erb
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /drafts/
+Disallow: /CNAME
+Disallow: /assets/
+Sitemap: <%= data.site.url %>/sitemap.xml

--- a/source/sitemap.txt.erb
+++ b/source/sitemap.txt.erb
@@ -1,0 +1,4 @@
+<% root_url = data.site.url %>
+<% sitemap.resources.each do |page| %>
+<%= "#{root_url}#{page.url}\n" if page.url !~ /\.(css|js|zip|eot|svg|WOFF|woff|woff2|ttf|png|jpg)$/ %>
+<% end %>

--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -1,0 +1,8 @@
+xml.instruct!
+xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
+  sitemap.resources.each do |resource|
+    xml.url do
+      xml.loc "#{data.site.url}#{resource.url}"
+    end if resource.url !~ /\.(css|js|zip|eot|svg|WOFF|woff|woff2|ttf|png|jpg)$/ 
+  end
+end


### PR DESCRIPTION
#### What?

Allow middleman to generate a sitemap for us based on existing directory structures. 

#### How To Test

Verify /sitemap.txt and /sitemap.xml show the subdirectories and that robots.txt dictates what should be crawled by bots

#### Tickets / Documentation

- [DEV-20](https://jira.bigcommerce.com/browse/DEV-20)

#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/9373485/21869411/24904456-d81d-11e6-9d29-f817b70027c2.png)

![image](https://cloud.githubusercontent.com/assets/9373485/21869547/bbd874c8-d81d-11e6-8162-87b7fb87087c.png)

