### PR TITLE
Orders & Coupons updates

### DIFF
--- a/source/includes/_api_objects_coupon.md
+++ b/source/includes/_api_objects_coupon.md
@@ -10,17 +10,37 @@ Category or product discounts that can be applied to orders for customers who en
 
 | Name | Type | Description |
 | --- | --- | --- |
-| id | int | coupon id |
+| id | int | The coupon's ID. |
 | name | string | The name of the coupon. |
-| type | enum | The coupon type field is an enumerated field and a value from the following list should be used. per_item_discount per_total_discount shipping_discount free_shipping percentage_discount |
-| amount | decimal | The amount is a decimal field which can either be the monetary discount to be applied to an order or a percentage discount to be applied to an order. The type of this field is determined by the coupon type. |
-| min_purchase | decimal | This is a decimal field which specifies the minimum value an order must have before the coupon can be applied to it. |
-| expires | date | This is a date field which specifies when a coupon expires. Coupons need not have an expiry date as you can also control expiry via max_uses and max_uses_per_customer. The date field must be formatted as per RFC-2822. |
-| enabled | boolean | This field's value is `true` if the coupon is enabled, otherwise `false`. |
-| code | string | The coupon code which customers will use to receive their discounts. Must be Unique. |
-| applies_to | object | This object provides ability to restrict a coupon to an entity type (category/product) and ability to restrict a coupon specific categories/products, where 0 is all categories/products. |
-| num_uses | int | Number of times this coupon has been used. This is a readonly field and can't be changed via PUT or POST. |
+| type | enum | Acceptable values for this enumerated field are: `per_item_discount`, `per_total_discount`, `shipping_discount`, `free_shipping`, or `percentage_discount`. |
+| amount | decimal | The discount to apply to an order, as either an amount or a percentage. This field's usage is determined by the coupon `type`. For example, a `type` of `percentage_discount` would determine a percentage here. |
+| min_purchase | decimal | Specifies a minimum value that an order must have before the coupon can be applied to it. |
+| expires | date | Specifies when a coupon expires. Coupons need not have an expiry date – you can also control expiry via `max_uses` or `max_uses_per_customer`. If you do use this date field, the value must be in <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a> format. |
+| enabled | boolean | If the coupon is enabled, this field's value is `true`; otherwise, `false`. |
+| code | string | The coupon code that customers will use to receive their discounts. Value must be unique. |
+| applies_to | object | Allows you to restrict a coupon to an entity type (category or product), and to specific categories/products. A value of `0` represents all categories/products. |
+| num_uses | int | Number of times this coupon has been used. This is a read-only field; do not set or modify its value in a POST or PUT request. |
 | max_uses | int | Maximum number of times this coupon can be used. |
 | max_uses_per_customer | int | Maximum number of times each customer can use this coupon. |
-| restricted_to | object | This field provides the ability to restrict coupon usage based on locations as follows If a coupon is restricted by country then a list of ISO2 country codes is provided. To retrieve these you can do a GET request on /countries.json endpoint. "restricted_to": { "countries": ["AU"] } If a coupon is restricted by states then a list of state names is provided indexed by the ISO2 country code for each country. To retrieve these you can do a GET request on /countries.json endpoint and then a GET request on /countries/:id/states.json endpoint. "restricted_to": { "states": { "AU": ["Australian Capital Territory"] } } If a coupon is restricted by zip codes then a list of zip codes indexed by the ISO2 country code for each country is provided as follows. Please refer to this KB article "restricted_to": { "zips": { "AU": ["2000", "20??"] } } |
-| shipping_methods | array | This is a list of shipping method names. If a shipping method isn't enabled on the store it can't be used to with a coupon. To check which shipping methods are enabled please do a GET request on the /shipping/methods.json endpoint. |
+| restricted_to | object | Allows you to restrict coupon usage based on locations, as follows:<br><br> To restrict a coupon by country, retrieve the list of ISO2 country codes  supported by BigCommmerce as described below under [Notes on Location Restrictions](#couponobjnote). Use the resulting ISO2 code as shown in this example: <br>  `"restricted_to": { "countries": ["AU"] }` <br><br> To restrict a coupon by state/province, retrieve BigCommmerce's list of supported state/province codes, indexed by ISO2 country codes, as described below under [Notes on Location Restrictions](#couponobjnote). Use the resulting state/province code as shown in this example: <br> `"restricted_to": { "states": { "AU": ["Australian Capital Territory"] } }` <br><br> To restrict a coupon by ZIP/postal codes, use BigCommerce's supported ZIP/postal-code patterns, which are indexed by ISO2 country codes. Please see <a href="https://support.bigcommerce.com/articles/Public/Adding-a-Shipping-Zone-by-Zip-or-Post-Code" target="_blank">this KB article</a> for an overview, and <a href="https://support.bigcommerce.com/articles/Public/Using-Coupon-Codes#advanced" target="_blank">this KB article</a> for format details. Use the resulting code as shown in this example: <br> `"restricted_to": { "zips": { "AU": ["2000", "20??"] } }` |
+| shipping_methods | array | This is a list of shipping-method names. A shipping method must be enabled on the store to use it with a coupon. To check which shipping methods are enabled, please use the [List&#160;Shipping Methods](/api/v2/#list-shipping-methods) endpoint. |
+
+### <span class="jumptarget" id="couponobjnote"> Notes on Location Restrictions </span>
+
+For the `locations` property listed above, you can look up all `country_iso2` codes supported by BigCommerce by using the [List&#160;Countries](/api/v2/#list-countries) endpoint, with a request of the following form: 
+
+```html
+https://{store_hash}/api/v2/countries?limit=250
+```
+
+To look up all `state_iso2` codes supported by BigCommerce, you can use the [List States](/api/v2/#list-countries) endpoint, with a request of the following form. (To&#160;supply its `{country_id}` parameter, query the [List Countries](/api/v2/#list-states) endpoint as described just above.)
+
+```html
+https://{store_hash}/api/v2/countries/{country_id}/states
+```   
+ 
+For example, to look up codes for all U.S. states and territories, you would use a request of the following form:
+ 
+```html
+https://{store_hash}/api/v2/countries/226/states?limit=100
+```

--- a/source/includes/_api_objects_order.md
+++ b/source/includes/_api_objects_order.md
@@ -11,38 +11,38 @@ The Order object contains a record of the purchase agreement between a shopper a
 | Name | Type | Description |
 | --- | --- | --- |
 | id | int | The ID of the order, a read-only value. Do not pass in PUT or POST. |
-| customer_id | int | The ID of the customer placing the order; or 0 if it was a guest order. |
-| date_created | date | The date this order was created, if not specified, will default to the current time. The date should be in RFC format, e.g.: 'Tue, 20 Nov 2012 00:00:00 +0000' |
+| customer_id | int | The ID of the customer placing the order; or `0` if it was a guest order. |
+| date_created | date | The date this order was created. If not specified, will default to the current time. The date should be in RFC format, e.g.: `Tue, 20 Nov 2012 00:00:00 +0000` |
 | date_modified | date | A read-only value representing the last modification of the order. Do not attempt to modify or set this value in a POST or PUT operation. |
 | date_shipped | date | A read-only value representing the date of shipment. Do not attempt to modify or set this value in a POST or PUT operation. |
-| status_id | int | The status ID, as detailed in the Order Statuses page (https://developer.bigcommerce.com/api/stores/v2/order_statuses). |
-| status | string | The status will include one of the string values listed in the Order Statuses page (https://developer.bigcommerce.com/api/stores/v2/order_statuses). This value is read-only. Do not attempt to modify or set this value in a POST or PUT operation. |
+| status_id | int | The status ID. See examples under [Order Statuses](/api/v2/#order-statuses). |
+| status | string | The status will include one of the string values defined under [Order Statuses](/api/v2/#order-statuses). This value is read-only. Do not attempt to modify or set this value in a POST or PUT operation. |
 | subtotal_ex_tax | decimal | Override value for subtotal excluding tax. If specified, the field `subtotal_inc_tax` is also required. |
 | subtotal_inc_tax | decimal | Override value for subtotal including tax. If specified, the field `subtotal_ex_tax` is also required. |
-| subtotal_tax | decimal | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. |
-| base_shipping_cost | decimal | The value of the base shipping cost |
-| shipping_cost_ex_tax | decimal | The value of shipping cost excluding tax |
-| shipping_cost_inc_tax | decimal | The value of shipping cost including tax |
+| subtotal_tax | decimal | A read-only value. Do not attempt to set or modify this value in a POST or PUT operation. |
+| base_shipping_cost | decimal | The value of the base shipping cost. |
+| shipping_cost_ex_tax | decimal | The value of shipping cost, excluding tax. |
+| shipping_cost_inc_tax | decimal | The value of shipping cost, including tax. |
 | shipping_cost_tax | decimal | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. |
-| shipping_cost_tax_class_id | int | Shipping-cost tax class. A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. NOTE: Value ignored if automatic tax is enabled on the store. |
-| base_handling_cost | decimal | The value of the base handling cost |
-| handling_cost_ex_tax | decimal | The value of the handling cost excluding tax |
-| handling_cost_inc_tax | decimal | The value of the handling cost including tax |
+| shipping_cost_tax_class_id | int | Shipping-cost tax class. A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. (NOTE: Value ignored if automatic tax is enabled on the store.) |
+| base_handling_cost | decimal | The value of the base handling cost. |
+| handling_cost_ex_tax | decimal | The value of the handling cost, excluding tax. |
+| handling_cost_inc_tax | decimal | The value of the handling cost, including tax. |
 | handling_cost_tax | decimal | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. |
-| handling_cost_tax_class_id | int | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. NOTE: Value ignored if automatic tax is enabled on the store. |
+| handling_cost_tax_class_id | int | A read-only value. Do not attempt to set or modify this value in a POST or PUT operation. (NOTE: Value ignored if automatic tax is enabled on the store.) |
 | base_wrapping_cost | decimal | The value of the base wrapping cost. |
-| wrapping_cost_ex_tax | decimal | The value of the wrapping cost excluding tax. |
-| wrapping_cost_inc_tax | decimal | The value of the wrapping cost including tax. |
+| wrapping_cost_ex_tax | decimal | The value of the wrapping cost, excluding tax. |
+| wrapping_cost_inc_tax | decimal | The value of the wrapping cost, including tax. |
 | wrapping_cost_tax | decimal | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. |
-| wrapping_cost_tax_class_id | int | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. NOTE: Value ignored if automatic tax is enabled on the store. |
+| wrapping_cost_tax_class_id | int | A read-only value. Do not attempt to set or modify this value in a POST or PUT operation. (NOTE: Value ignored if automatic tax is enabled on the store.) |
 | total_ex_tax | decimal | Override value for the total, excluding tax. If specified, the field `total_inc_tax` is also required. |
 | total_inc_tax | decimal | Override value for the total, including tax. If specified, the field `total_ex_tax` is also required. |
-| total_tax | decimal | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. |
+| total_tax | decimal | A read-only value. Do not attempt to set or modify this value in a POST or PUT operation. |
 | items_total | int | The total number of items in the order. |
 | items_shipped | int | The number of items that have been shipped. |
-| payment_method | string | The payment method for this order. Can be one of the following: Manual, Credit Card, cash, Test Payment Gateway, ... . |
+| payment_method | string | The payment method for this order. Can be one of the following: `Manual`, `Credit Card`, `cash`, `Test Payment Gateway`, etc. |
 | payment_provider_id | string | The external Transaction ID/Payment ID within this order's payment provider (if a payment provider was used). |
-| payment_status | enum | A read-only value. Do not attempt to modify or set this value in a POST or PUT operation. |
+| payment_status | enum | A read-only value. Do not attempt to set or modify this value in a POST or PUT operation. |
 | refunded_amount | decimal | The amount refunded from this transaction. |
 | order_is_digital | boolean | Whether this is an order for digital products. |
 | store_credit_amount | decimal | Represents the store credit that the shopper has redeemed on this individual order. This is a read-only value. Do not pass in a POST or PUT. |
@@ -61,14 +61,14 @@ The Order object contains a record of the purchase agreement between a shopper a
 | coupon_discount | decimal | A read-only value. Do not pass in a POST or PUT. |
 | shipping_address_count | int | The number of shipping addresses associated with this transaction. A read-only value. Do not pass in a POST or PUT. |
 | is_deleted | boolean | Indicates whether the order was deleted (archived). A read-only value. Do not pass in a POST or PUT. |
-| is_email_opt_in | boolean | Indicates whether the shopper has selected an opt-in check box, on the checkout page, to receive emails. A read-only value. Do not pass in a POST or PUT. |
-| ebay_order_id | string | If the order was placed through eBay, the eBay order number will be included. Otherwise, the value will be 0. |
-| billing_address | object | The billing address object contains the billing address details for this transaction, specifically: first_name, last_name, company, street_1, street_2, city, state, zip, country, country_iso2, phone, and email. Ensure that state names are spelled out in full, e.g.: California. Required for POST operations. |
-| order_source | string | Orders submitted via the store's website will include a "www" value. Orders submitted via the API will be set to "external". A read-only value. Do not pass in a POST or PUT. |
-| external_source | string | For orders submitted or modified via the API, using a PUT or POST operation, you can optionally pass in a value identifying the system used to generate the order. For example: "POS". Otherwise, the value will be null. |
-| products | object|array | Refer to https://developer.bigcommerce.com/api/orders/order/products |
-| shipping_addresses | object|array | For PUT and POST operations, you can optionally pass a "shipping_addresses" object array, containing one or more shipping addresses. If you include more than one address, only the first will be used, as the API does not currently support shipping to more than one address. If you do not pass a shipping address, the billing address will be used. Refer to the "Order Shipping Address" page for the full list of name/value pairs (https://developer.bigcommerce.com/api/objects/v2/order_shipping_address). Not all fields are required. For an example of the syntax, refer to the Objects resource > "Create order" entry. For GET and other operations, the `shipping_addresses` object will consist of two addresses: the URI of a JSON object containing the shipping address details; and a context path that provides an alternate means of retrieving the data (if, for example, you prefer XML). For the syntax, refer to the Objects resource > "List orders" entry. |
-| coupons | object | A read-only value. Do not attempt to pass in a PUT or POST. The coupons object contains two name/value pairs. The value paired with "url" is the fully qualified address of the JSON object array that contains details of the coupon(s) associated with this transaction, if any. The value of "resource" is the context path to the "coupons" resource, which represents an alternate means of retrieving the data (if, for example, you prefer XML). |
+| is_email_opt_in | boolean | Indicates whether the shopper has selected an opt-in check box (on the checkout page) to receive emails. A read-only value. Do not pass in a POST or PUT. |
+| ebay_order_id | string | If the order was placed through eBay, the eBay order number will be included. Otherwise, the value will be `0`. |
+| billing_address | object | Contains the billing address details for this transaction, specifically: `first_name`, `last_name`, `company`, `street_1`, `street_2`, `city`, `state`, `zip`, `country`, `country_iso2`, `phone`, and `email`. Ensure that state names are spelled out in full, e.g.: `California`. Required for POST operations. |
+| order_source | string | Orders submitted via the store's website will include a `www` value. Orders submitted via the API will be set to `external`. A read-only value. Do not pass in a POST or PUT. |
+| external_source | string | For orders submitted or modified via the API, using a PUT or POST operation, you can optionally pass in a value identifying the system used to generate the order. For example: `POS`. Otherwise, the value will be null. |
+| products | array | Array of [product](/api/v2/#product-object-properties) objects that make up the order. |
+| shipping_addresses | array | This is an object array that has different syntax in different operations: <br><br> In PUT or POST operations, you can optionally pass a `shipping_addresses` object array containing one or more shipping addresses. However, if you include more than one address, only the first address will be used, because the API does not currently support shipping to more than one address. If you do not pass a shipping address, the billing address will be used. <br><br> For the full list of available name/value pairs, see the [Order Shipping Addresses](/api/v2/#order-shipping-addresses) object. Not all fields are required. For a syntax example of syntax, see the [Create an Order](/api/v2/#create-an-order) endpoint.<br><br> In GET and other operations, the `shipping_addresses` object will consist of two addresses. The first is the URI of a JSON object containing the shipping address details. The second is a context path that provides an alternate means of retrieving the data (if, for example, you prefer XML). For syntax, refer to the [List Orders](/api/v2/#list-orders) endpoint. |
+| coupons | object | This object is read-only. Do not attempt to pass in a PUT or POST. Contains two name/value pairs: <br> The `url` property's value is the fully qualified address of a JSON object array, containing details of any coupon(s) associated with this transaction. <br> The `resource` property's value is the context path to the [Order Coupons](/api/v2/#order-coupons) resource, which provides an alternate means of retrieving the data (if, for example, you prefer XML). |
 
 ### <span class="jumptarget"> Order Webhook Events </span>
 

--- a/source/includes/_api_objects_order_status.md
+++ b/source/includes/_api_objects_order_status.md
@@ -2,7 +2,7 @@
 
 Each order status represents a state in the order fulfillment workflow.
 
-### <span class="jumptarget"> Order Status Object - Properties </span>
+### <span class="jumptarget"> Order Status Object – Properties </span>
 
 | Name | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
Reset fictitious, broken, or vague links. Rewrote descriptions for brevity and readability.